### PR TITLE
Add parallel execution

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 tests/testthat/fixtures/integration/ds004869_testdata\.tar\.gz$
 tests/testthat/fixtures/integration/prepare_testdata\.sh$
 tests/testthat/fixtures/integration/README\.md$
+^test_parallel$
+^PLAN\.md$

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Run integration tests
         env:
           PETFIT_INTEGRATION_TESTS: "true"
+          PETFIT_PARALLEL_TESTS: "true"
           PETFIT_INTEGRATION_CACHE: /tmp/petfit_integration
         run: |
           Rscript -e "devtools::test(filter = 'integration')"
@@ -98,9 +99,10 @@ jobs:
         env:
           PETFIT_INTEGRATION_TESTS: "true"
           PETFIT_DOCKER_TESTS: "true"
+          PETFIT_PARALLEL_TESTS: "true"
           PETFIT_INTEGRATION_CACHE: /tmp/petfit_integration
         run: |
-          Rscript -e "devtools::test(filter = 'integration-docker')"
+          Rscript -e "devtools::test(filter = 'integration.*docker')"
 
   # =========================================================================
   # Job 3: Apptainer/Singularity container tests
@@ -149,6 +151,7 @@ jobs:
         env:
           PETFIT_INTEGRATION_TESTS: "true"
           PETFIT_SINGULARITY_TESTS: "true"
+          PETFIT_PARALLEL_TESTS: "true"
           PETFIT_INTEGRATION_CACHE: /tmp/petfit_integration
         run: |
-          Rscript -e "devtools::test(filter = 'integration-singularity')"
+          Rscript -e "devtools::test(filter = 'integration.*singularity')"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     kinfitr,
     future,
     furrr,
+    ggbeeswarm,
     tidyverse
 Suggests:
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,9 @@ Imports:
     optparse,
     plotly,
     readr,
-    kinfitr
+    kinfitr,
+    future,
+    furrr
 Suggests:
     testthat (>= 3.0.0),
     here

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: petfit
 Title: PETFit BIDS App Configuration Interface
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     c(person("Granville", "Matheson", , "granville.matheson@ki.se", role = c("aut", "cre")),
     person("Alessio", "Giacomel", , "alessio.giacomel@kcl.ac.uk", role = c("ctb")),

--- a/R/docker_functions.R
+++ b/R/docker_functions.R
@@ -145,7 +145,7 @@ validate_blood_requirements <- function(config, step = NULL, blood_dir = NULL) {
 #' @param petfit_output_foldername Character string name for petfit output folder within derivatives (default: "petfit")
 #' @return List with execution result and messages
 #' @export
-petfit_regiondef_auto <- function(bids_dir = NULL, derivatives_dir = NULL, petfit_output_foldername = "petfit") {
+petfit_regiondef_auto <- function(bids_dir = NULL, derivatives_dir = NULL, petfit_output_foldername = "petfit", cores = 1L) {
 
   result <- list(
     success = FALSE,
@@ -254,7 +254,8 @@ petfit_regiondef_auto <- function(bids_dir = NULL, derivatives_dir = NULL, petfi
       derivatives_dir,
       output_folder,
       bids_dir,
-      participant_data
+      participant_data,
+      cores = cores
     )
 
     # Generate summary
@@ -347,7 +348,8 @@ petfit_modelling_auto <- function(bids_dir = NULL,
                                    analysis_subfolder = "Primary_Analysis",
                                    blood_dir = NULL,
                                    step = NULL,
-                                   pipeline_type = NULL) {
+                                   pipeline_type = NULL,
+                                   cores = 1L) {
 
   result <- list(
     success = FALSE,
@@ -463,6 +465,7 @@ petfit_modelling_auto <- function(bids_dir = NULL,
         petfit_dir = petfit_base_dir,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -473,6 +476,7 @@ petfit_modelling_auto <- function(bids_dir = NULL,
         output_dir = analysis_folder,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -483,6 +487,7 @@ petfit_modelling_auto <- function(bids_dir = NULL,
         output_dir = analysis_folder,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -492,6 +497,7 @@ petfit_modelling_auto <- function(bids_dir = NULL,
         config_path = config_path,
         output_dir = analysis_folder,
         bids_dir = bids_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -504,6 +510,7 @@ petfit_modelling_auto <- function(bids_dir = NULL,
         output_dir = analysis_folder,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
     }

--- a/R/launch_apps.R
+++ b/R/launch_apps.R
@@ -40,7 +40,8 @@ launch_petfit_apps <- function(app = c("regiondef", "modelling_plasma", "modelli
                                blood_dir = NULL,
                                petfit_output_foldername = "petfit",
                                subfolder = "Primary_Analysis",
-                               config_file = NULL) {
+                               config_file = NULL,
+                               cores = 1L) {
 
   # Validate app parameter
   app <- match.arg(app, choices = c("regiondef", "modelling_plasma", "modelling_ref"))
@@ -85,7 +86,8 @@ launch_petfit_apps <- function(app = c("regiondef", "modelling_plasma", "modelli
       region_definition_app(
         bids_dir = bids_dir,
         derivatives_dir = derivatives_dir,
-        petfit_output_foldername = petfit_output_foldername
+        petfit_output_foldername = petfit_output_foldername,
+        cores = cores
       )
     },
     modelling_plasma = {
@@ -94,7 +96,8 @@ launch_petfit_apps <- function(app = c("regiondef", "modelling_plasma", "modelli
         derivatives_dir = derivatives_dir,
         blood_dir = blood_dir,
         subfolder = subfolder,
-        config_file = config_file
+        config_file = config_file,
+        cores = cores
       )
     },
     modelling_ref = {
@@ -103,7 +106,8 @@ launch_petfit_apps <- function(app = c("regiondef", "modelling_plasma", "modelli
         derivatives_dir = derivatives_dir,
         blood_dir = blood_dir,
         subfolder = subfolder,
-        config_file = config_file
+        config_file = config_file,
+        cores = cores
       )
     }
   )

--- a/R/modelling_plasma_app.R
+++ b/R/modelling_plasma_app.R
@@ -8,7 +8,7 @@
 #' @param subfolder Character string name for analysis subfolder (default: "Primary_Analysis")
 #' @param config_file Character string path to existing config file (optional)
 #' @export
-modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir = NULL, subfolder = "Primary_Analysis", config_file = NULL) {
+modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir = NULL, subfolder = "Primary_Analysis", config_file = NULL, cores = 1L) {
   
   # Set derivatives directory logic
   if (is.null(derivatives_dir)) {
@@ -2625,6 +2625,7 @@ modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_
         petfit_dir = petfit_dir,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -2649,6 +2650,7 @@ modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_
         output_dir = output_dir,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -2673,6 +2675,7 @@ modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_
         output_dir = output_dir,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -2743,6 +2746,7 @@ modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_
         output_dir = output_dir,
         bids_dir = bids_dir,
         blood_dir = blood_dir,
+        cores = cores,
         notify = notify
       )
 

--- a/R/modelling_ref_app.R
+++ b/R/modelling_ref_app.R
@@ -8,7 +8,7 @@
 #' @param subfolder Character string name for analysis subfolder (default: "Primary_Analysis")
 #' @param config_file Character string path to existing config file (optional)
 #' @export
-modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir = NULL, subfolder = "Primary_Analysis", config_file = NULL) {
+modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir = NULL, subfolder = "Primary_Analysis", config_file = NULL, cores = 1L) {
   
   # Set derivatives directory logic
   if (is.null(derivatives_dir)) {
@@ -2474,6 +2474,7 @@ modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir
         petfit_dir = petfit_dir,
         bids_dir = bids_dir,
         blood_dir = NULL,  # Reference tissue models don't use blood data
+        cores = cores,
         notify = notify
       )
 
@@ -2498,6 +2499,7 @@ modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir
         output_dir = output_dir,
         bids_dir = bids_dir,
         blood_dir = NULL,  # Reference tissue models don't use blood data
+        cores = cores,
         notify = notify
       )
 
@@ -2521,6 +2523,7 @@ modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir
         config_path = config_path,
         output_dir = output_dir,
         bids_dir = bids_dir,
+        cores = cores,
         notify = notify
       )
 
@@ -2591,6 +2594,7 @@ modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir
         output_dir = output_dir,
         bids_dir = bids_dir,
         blood_dir = NULL,  # Reference tissue models don't use blood data
+        cores = cores,
         notify = notify
       )
 

--- a/R/pipeline_core.R
+++ b/R/pipeline_core.R
@@ -22,6 +22,7 @@
 #' @export
 execute_datadef_step <- function(config_path, output_dir, petfit_dir,
                                   bids_dir = NULL, blood_dir = NULL,
+                                  cores = 1L,
                                   notify = function(msg, type) {}) {
 
   result <- list(success = FALSE, message = "", files_created = 0)
@@ -130,7 +131,8 @@ execute_datadef_step <- function(config_path, output_dir, petfit_dir,
         step_name = "data_definition",
         analysis_folder = output_dir,
         bids_dir = bids_dir,
-        blood_dir = blood_dir
+        blood_dir = blood_dir,
+        cores = cores
       )
     }, error = function(e) {
       cat("Warning: Could not generate data definition report:", e$message, "\n")
@@ -169,6 +171,7 @@ execute_datadef_step <- function(config_path, output_dir, petfit_dir,
 #' @export
 execute_weights_step <- function(config_path, output_dir,
                                   bids_dir = NULL, blood_dir = NULL,
+                                  cores = 1L,
                                   notify = function(msg, type) {}) {
 
   result <- list(success = FALSE, message = "")
@@ -193,7 +196,8 @@ execute_weights_step <- function(config_path, output_dir,
         step_name = "weights",
         analysis_folder = output_dir,
         bids_dir = bids_dir,
-        blood_dir = blood_dir
+        blood_dir = blood_dir,
+        cores = cores
       )
     }, error = function(e) {
       cat("Error generating weights report:", e$message, "\n")
@@ -232,6 +236,7 @@ execute_weights_step <- function(config_path, output_dir,
 #' @export
 execute_delay_step <- function(config_path, output_dir,
                                bids_dir = NULL, blood_dir = NULL,
+                               cores = 1L,
                                notify = function(msg, type) {}) {
 
   result <- list(success = FALSE, message = "")
@@ -282,7 +287,8 @@ execute_delay_step <- function(config_path, output_dir,
         step_name = "delay",
         analysis_folder = output_dir,
         bids_dir = bids_dir,
-        blood_dir = blood_dir
+        blood_dir = blood_dir,
+        cores = cores
       )
     }, error = function(e) {
       cat("Warning: Could not generate delay report:", e$message, "\n")
@@ -320,6 +326,7 @@ execute_delay_step <- function(config_path, output_dir,
 #' @export
 execute_reference_tac_step <- function(config_path, output_dir,
                                        bids_dir = NULL,
+                                       cores = 1L,
                                        notify = function(msg, type) {}) {
 
   result <- list(success = FALSE, message = "")
@@ -344,7 +351,8 @@ execute_reference_tac_step <- function(config_path, output_dir,
         step_name = "reference_tac",
         analysis_folder = output_dir,
         bids_dir = bids_dir,
-        blood_dir = NULL
+        blood_dir = NULL,
+        cores = cores
       )
     }, error = function(e) {
       cat("Error generating reference TAC report:", e$message, "\n")
@@ -384,6 +392,7 @@ execute_reference_tac_step <- function(config_path, output_dir,
 #' @export
 execute_model_step <- function(config_path, model_num, output_dir,
                                bids_dir = NULL, blood_dir = NULL,
+                               cores = 1L,
                                notify = function(msg, type) {}) {
 
   result <- list(success = FALSE, message = "")
@@ -422,7 +431,8 @@ execute_model_step <- function(config_path, model_num, output_dir,
         model_number = paste("Model", model_num),
         analysis_folder = output_dir,
         bids_dir = bids_dir,
-        blood_dir = blood_dir
+        blood_dir = blood_dir,
+        cores = cores
       )
     }, error = function(e) {
       cat("Warning: Could not generate Model", model_num, "report:", e$message, "\n")

--- a/R/region_definition_app.R
+++ b/R/region_definition_app.R
@@ -9,7 +9,7 @@
 #'   - bids_dir/code/petfit if bids_dir provided
 #'   - derivatives_dir/petfit_output_foldername if no bids_dir
 #' @export
-region_definition_app <- function(bids_dir = NULL, derivatives_dir = NULL, petfit_output_foldername = "petfit") {
+region_definition_app <- function(bids_dir = NULL, derivatives_dir = NULL, petfit_output_foldername = "petfit", cores = 1L) {
   
   # Set derivatives directory logic
   if (is.null(derivatives_dir)) {
@@ -1005,7 +1005,7 @@ region_definition_app <- function(bids_dir = NULL, derivatives_dir = NULL, petfi
         cat("Processing all regions...\n")
         
         # Use consolidated TACs creation instead of separate files
-        combined_data <- create_petfit_combined_tacs(petfit_regions_files_path, derivatives_folder, combined_output_folder, bids_dir, participant_data)
+        combined_data <- create_petfit_combined_tacs(petfit_regions_files_path, derivatives_folder, combined_output_folder, bids_dir, participant_data, cores = cores)
         
         # Show success notification with summary  
         total_rows <- nrow(combined_data)

--- a/R/region_utils.R
+++ b/R/region_utils.R
@@ -802,7 +802,7 @@ calculate_segmentation_mean_tac <- function(derivatives_folder, tacs_relative_pa
 #' @param participant_data Participant data loaded from BIDS directory (optional)
 #' @return Tibble with all combined TACs data in long format with BIDS attributes
 #' @export
-create_petfit_combined_tacs <- function(petfit_regions_files_path, derivatives_folder, output_dir, bids_dir = NULL, participant_data = NULL) {
+create_petfit_combined_tacs <- function(petfit_regions_files_path, derivatives_folder, output_dir, bids_dir = NULL, participant_data = NULL, cores = 1L) {
   
   # Validate inputs
   if (!file.exists(petfit_regions_files_path)) {
@@ -850,8 +850,18 @@ create_petfit_combined_tacs <- function(petfit_regions_files_path, derivatives_f
     cat("Detected TAC units from", first_tacs_file, ":", original_tac_units, "\n")
   }
   
+  # Set up parallel processing
+  if (cores > 1L) {
+    if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+    on.exit(future::plan(future::sequential), add = TRUE)
+  }
+
   # Process all file pairs and collect results
-  all_combined_data <- purrr::map_dfr(1:nrow(file_groups), function(i) {
+  all_combined_data <- furrr::future_map_dfr(1:nrow(file_groups), function(i) {
     tacs_file <- file_groups$tacs_filename[i]
     morph_file <- file_groups$morph_filename[i]
     regions_data <- file_groups$regions_data[[i]]
@@ -995,7 +1005,7 @@ create_petfit_combined_tacs <- function(petfit_regions_files_path, derivatives_f
       dplyr::select(dplyr::all_of(column_order[column_order %in% colnames(.)]))  # Only select columns that exist
 
     return(combined_results_with_bids)
-  })
+  }, .options = furrr::furrr_options(seed = TRUE))
   
   if (nrow(all_combined_data) == 0) {
     warning("No regions were successfully combined across all files")

--- a/R/report_generation.R
+++ b/R/report_generation.R
@@ -10,7 +10,7 @@
 #' 
 #' @return Character string path to the generated report file
 #' @export
-generate_step_report <- function(step_name, analysis_folder, output_dir = NULL, bids_dir = NULL, blood_dir = NULL) {
+generate_step_report <- function(step_name, analysis_folder, output_dir = NULL, bids_dir = NULL, blood_dir = NULL, cores = 1L) {
   
   # Set default output directory
   if (is.null(output_dir)) {
@@ -36,6 +36,7 @@ generate_step_report <- function(step_name, analysis_folder, output_dir = NULL, 
   
   # Prepare parameters - reports are now self-deriving
   params <- list(
+    cores = cores,
     analysis_folder = analysis_folder,
     bids_dir = bids_dir,
     blood_dir = blood_dir
@@ -75,8 +76,8 @@ generate_step_report <- function(step_name, analysis_folder, output_dir = NULL, 
 #' 
 #' @return Character string path to the generated report file
 #' @export
-generate_model_report <- function(model_type, model_number, analysis_folder, 
-                                 output_dir = NULL, bids_dir = NULL, blood_dir = NULL) {
+generate_model_report <- function(model_type, model_number, analysis_folder,
+                                 output_dir = NULL, bids_dir = NULL, blood_dir = NULL, cores = 1L) {
   
   # Set default output directory
   if (is.null(output_dir)) {
@@ -105,6 +106,7 @@ generate_model_report <- function(model_type, model_number, analysis_folder,
   
   # Prepare parameters
   params <- list(
+    cores = cores,
     model_number = model_number,
     analysis_folder = analysis_folder,
     bids_dir = bids_dir,
@@ -181,7 +183,7 @@ get_model_template <- function(model_type) {
 #' @return Character string path to the generated report file
 #' @export
 generate_tstar_report <- function(analysis_folder, tstar_results = NULL, binding_regions = NULL,
-                                 output_dir = NULL) {
+                                 output_dir = NULL, cores = 1L) {
   
   # Set default output directory
   if (is.null(output_dir)) {
@@ -206,6 +208,7 @@ generate_tstar_report <- function(analysis_folder, tstar_results = NULL, binding
   
   # Prepare parameters
   params <- list(
+    cores = cores,
     analysis_folder = analysis_folder,
     tstar_results = tstar_results,
     binding_regions = binding_regions

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -2,7 +2,7 @@
 # Build Docker image from the docker directory
 
 # Set version
-VERSION="v0.1.1"
+VERSION="v0.1.2"
 
 # Build with version tag (build context is parent directory)
 docker build -f Dockerfile -t mathesong/petfit:${VERSION} .. --platform linux/amd64

--- a/docker/run_petfit.R
+++ b/docker/run_petfit.R
@@ -15,8 +15,10 @@ option_list <- list(
               help="Step to run in automatic mode: 'datadef', 'weights', 'delay', 'reference_tac', 'model1', 'model2', 'model3' [optional]"),
   make_option(c("--petfit_output_foldername"), type="character", default="petfit", 
               help="Name for petfit output folder within derivatives [default: petfit]"),
-  make_option(c("--analysis_foldername"), type="character", default="Primary_Analysis", 
-              help="Name for analysis subfolder [default: Primary_Analysis]")
+  make_option(c("--analysis_foldername"), type="character", default="Primary_Analysis",
+              help="Name for analysis subfolder [default: Primary_Analysis]"),
+  make_option(c("--cores"), type="integer", default=1L,
+              help="Number of cores for parallel processing [default: 1]")
 )
 
 # Parse arguments
@@ -119,21 +121,24 @@ if (opt$mode == "interactive") {
     region_definition_app(
       bids_dir = dirs$bids_dir,
       derivatives_dir = dirs$derivatives_dir,
-      petfit_output_foldername = opt$petfit_output_foldername
+      petfit_output_foldername = opt$petfit_output_foldername,
+      cores = opt$cores
     )
   } else if (opt$func == "modelling_plasma") {
     modelling_plasma_app(
       bids_dir = dirs$bids_dir,
       derivatives_dir = dirs$derivatives_dir,
       blood_dir = dirs$blood_dir,
-      subfolder = opt$analysis_foldername
+      subfolder = opt$analysis_foldername,
+      cores = opt$cores
     )
   } else if (opt$func == "modelling_ref") {
     modelling_ref_app(
       bids_dir = dirs$bids_dir,
       derivatives_dir = dirs$derivatives_dir,
       blood_dir = dirs$blood_dir,
-      subfolder = opt$analysis_foldername
+      subfolder = opt$analysis_foldername,
+      cores = opt$cores
     )
   }
 
@@ -151,7 +156,8 @@ if (opt$mode == "interactive") {
       result <- petfit_regiondef_auto(
         bids_dir = dirs$bids_dir,
         derivatives_dir = dirs$derivatives_dir,
-        petfit_output_foldername = opt$petfit_output_foldername
+        petfit_output_foldername = opt$petfit_output_foldername,
+        cores = opt$cores
       )
 
       # Print all messages
@@ -195,7 +201,8 @@ if (opt$mode == "interactive") {
         petfit_output_foldername = opt$petfit_output_foldername,
         blood_dir = dirs$blood_dir,
         step = opt$step,
-        pipeline_type = if (opt$func == "modelling_plasma") "plasma" else "reference"
+        pipeline_type = if (opt$func == "modelling_plasma") "plasma" else "reference",
+        cores = opt$cores
       )
 
       # Print all messages

--- a/inst/rmd/1tcm_report.Rmd
+++ b/inst/rmd/1tcm_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: NULL
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,8 +22,20 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
 
 theme_set(theme_light())
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 # Use parameters (from params or debugging section above)
 analysis_folder <- params$analysis_folder %||% analysis_folder
@@ -491,48 +504,48 @@ if (!is.null(subset_config) && (!is.null(subset_config$start) || !is.null(subset
 safe_onetcm <- possibly(onetcm, otherwise = NA)
 
 if(vB_source == "fit") {
-  
+
   # Fit 1TCM model to all regional TACs
-  model_data <- model_data %>% 
-    group_by(output_stem, region) %>% 
-    mutate(fit_1tcm = pmap(list(tacs, input, inpshift),
-                           ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                   input = ..2, 
+  model_data <- model_data %>%
+    mutate(fit_1tcm = future_pmap(list(tacs, input, inpshift),
+                           ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                   input = ..2,
                                    weights = ..1$weights,
                                    inpshift = ..3,
                                    frameStartEnd = frameStartEnd,
                                    timeStartEnd = timeStartEnd,
                                    K1.start = K1_start,
-                                   K1.lower = K1_lower, 
+                                   K1.lower = K1_lower,
                                    K1.upper = K1_upper,
                                    k2.start = k2_start,
                                    k2.lower = k2_lower,
                                    k2.upper = k2_upper,
-                                   multstart_iter = multstart_iter))) %>%
-    ungroup() %>% 
+                                   multstart_iter = multstart_iter),
+                           .options = furrr_options(seed = TRUE))) %>%
+    ungroup() %>%
     mutate(success = map_dbl(fit_1tcm, length) > 1)
   
 } else {
   
     # Fit 1TCM model to all regional TACs
-    model_data <- model_data %>% 
-      group_by(output_stem, region) %>% 
-      mutate(fit_1tcm = pmap(list(tacs, input, inpshift, vB),
-                             ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                     input = ..2, 
+    model_data <- model_data %>%
+      mutate(fit_1tcm = future_pmap(list(tacs, input, inpshift, vB),
+                             ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                     input = ..2,
                                      weights = ..1$weights,
                                      inpshift = ..3,
                                      vB = ..4,
                                      frameStartEnd = frameStartEnd,
                                      timeStartEnd = timeStartEnd,
                                      K1.start = K1_start,
-                                     K1.lower = K1_lower, 
+                                     K1.lower = K1_lower,
                                      K1.upper = K1_upper,
                                      k2.start = k2_start,
                                      k2.lower = k2_lower,
                                      k2.upper = k2_upper,
-                                     multstart_iter = multstart_iter))) %>%
-      ungroup() %>% 
+                                     multstart_iter = multstart_iter),
+                             .options = furrr_options(seed = TRUE))) %>%
+      ungroup() %>%
       mutate(success = map_dbl(fit_1tcm, length) > 1)
   
 }
@@ -663,30 +676,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_1tcm, region, title), 
-                        ~plot(..1, roiname=..2) + 
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>% 
-  pull(fitplot)
+```{r, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_1tcm, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_1tcm, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_1tcm, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -818,6 +875,10 @@ walk2(savefits_pet$jsondat,
       ~writeLines(.x, .y))
 ```
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/2tcm_report.Rmd
+++ b/inst/rmd/2tcm_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,9 +22,20 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
-theme_set(theme_light())
+library(furrr)
 
 theme_set(theme_light())
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 # Use parameters (from params or debugging section above)
 analysis_folder <- params$analysis_folder %||% analysis_folder
@@ -506,19 +518,18 @@ if (!is.null(subset_config) && (!is.null(subset_config$start) || !is.null(subset
 safe_twotcm <- possibly(twotcm, otherwise = NA)
 
 if(vB_source == "fit") {
-  
+
   # Fit 2TCM model to all regional TACs
-  model_data <- model_data %>% 
-    group_by(output_stem, region) %>% 
-    mutate(fit_2tcm = pmap(list(tacs, input, inpshift),
-                           ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                   input = ..2, 
+  model_data <- model_data %>%
+    mutate(fit_2tcm = future_pmap(list(tacs, input, inpshift),
+                           ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                   input = ..2,
                                    weights = ..1$weights,
                                    inpshift = ..3,
                                    frameStartEnd = frameStartEnd,
                                    timeStartEnd = timeStartEnd,
                                    K1.start = K1_start,
-                                   K1.lower = K1_lower, 
+                                   K1.lower = K1_lower,
                                    K1.upper = K1_upper,
                                    k2.start = k2_start,
                                    k2.lower = k2_lower,
@@ -529,25 +540,25 @@ if(vB_source == "fit") {
                                    k4.start = k4_start,
                                    k4.lower = k4_lower,
                                    k4.upper = k4_upper,
-                                   multstart_iter = multstart_iter))) %>%
-    ungroup() %>% 
+                                   multstart_iter = multstart_iter),
+                           .options = furrr_options(seed = TRUE))) %>%
+    ungroup() %>%
     mutate(success = map_dbl(fit_2tcm, length) > 1)
   
 } else {
   
     # Fit 2TCM model to all regional TACs
-    model_data <- model_data %>% 
-      group_by(output_stem, region) %>% 
-      mutate(fit_2tcm = pmap(list(tacs, input, inpshift, vB),
-                             ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                     input = ..2, 
+    model_data <- model_data %>%
+      mutate(fit_2tcm = future_pmap(list(tacs, input, inpshift, vB),
+                             ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                     input = ..2,
                                      weights = ..1$weights,
                                      inpshift = ..3,
                                      vB = ..4,
                                      frameStartEnd = frameStartEnd,
                                      timeStartEnd = timeStartEnd,
                                      K1.start = K1_start,
-                                     K1.lower = K1_lower, 
+                                     K1.lower = K1_lower,
                                      K1.upper = K1_upper,
                                      k2.start = k2_start,
                                      k2.lower = k2_lower,
@@ -558,8 +569,9 @@ if(vB_source == "fit") {
                                      k4.start = k4_start,
                                      k4.lower = k4_lower,
                                      k4.upper = k4_upper,
-                                     multstart_iter = multstart_iter))) %>%
-      ungroup() %>% 
+                                     multstart_iter = multstart_iter),
+                             .options = furrr_options(seed = TRUE))) %>%
+      ungroup() %>%
       mutate(success = map_dbl(fit_2tcm, length) > 1)
   
 }
@@ -691,30 +703,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_2tcm, region, title), 
-                        ~plot(..1, roiname=..2) + 
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>% 
-  pull(fitplot)
+```{r, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_2tcm, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_2tcm, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_2tcm, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -850,6 +906,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/2tcmirr_report.Rmd
+++ b/inst/rmd/2tcmirr_report.Rmd
@@ -6,6 +6,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -20,9 +21,20 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
-theme_set(theme_light())
+library(furrr)
 
 theme_set(theme_light())
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 # Use parameters (from params or debugging section above)
 analysis_folder <- params$analysis_folder %||% analysis_folder
@@ -503,8 +515,7 @@ if(vB_source == "fit") {
 
   # Fit 2TCM_irr model to all regional TACs
   model_data <- model_data %>%
-    group_by(output_stem, region) %>%
-    mutate(fit_2tcm_irr = pmap(list(tacs, input, inpshift),
+    mutate(fit_2tcm_irr = future_pmap(list(tacs, input, inpshift),
                            ~safe_twotcm_irr(t_tac = ..1$frame_mid, tac = ..1$TAC,
                                    input = ..2,
                                    weights = ..1$weights,
@@ -520,7 +531,8 @@ if(vB_source == "fit") {
                                    k3.start = k3_start,
                                    k3.lower = k3_lower,
                                    k3.upper = k3_upper,
-                                   multstart_iter = multstart_iter))) %>%
+                                   multstart_iter = multstart_iter),
+                           .options = furrr_options(seed = TRUE))) %>%
     ungroup() %>%
     mutate(success = map_dbl(fit_2tcm_irr, length) > 1)
 
@@ -528,8 +540,7 @@ if(vB_source == "fit") {
 
     # Fit 2TCM_irr model to all regional TACs
     model_data <- model_data %>%
-      group_by(output_stem, region) %>%
-      mutate(fit_2tcm_irr = pmap(list(tacs, input, inpshift, vB),
+      mutate(fit_2tcm_irr = future_pmap(list(tacs, input, inpshift, vB),
                              ~safe_twotcm_irr(t_tac = ..1$frame_mid, tac = ..1$TAC,
                                      input = ..2,
                                      weights = ..1$weights,
@@ -546,7 +557,8 @@ if(vB_source == "fit") {
                                      k3.start = k3_start,
                                      k3.lower = k3_lower,
                                      k3.upper = k3_upper,
-                                     multstart_iter = multstart_iter))) %>%
+                                     multstart_iter = multstart_iter),
+                             .options = furrr_options(seed = TRUE))) %>%
       ungroup() %>%
       mutate(success = map_dbl(fit_2tcm_irr, length) > 1)
 
@@ -679,30 +691,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_2tcm_irr, region, title), 
-                        ~plot(..1, roiname=..2) + 
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>% 
-  pull(fitplot)
+```{r, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_2tcm_irr, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_2tcm_irr, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_2tcm_irr, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -837,6 +893,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/data_definition_report.Rmd
+++ b/inst/rmd/data_definition_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   analysis_folder: NULL
   bids_dir: NULL
   blood_dir: NULL

--- a/inst/rmd/delay_report.Rmd
+++ b/inst/rmd/delay_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   analysis_folder: NULL
   bids_dir: NULL
   blood_dir: NULL
@@ -20,6 +21,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 theme_set(theme_light())
 
@@ -388,7 +402,7 @@ inpshift_upper <- config$FitDelay$inpshift_upper %||% 0.5
 safe_onetcm <- possibly(onetcm, otherwise = NA)
 
 model_data <- model_data %>%
-  mutate(delayFit = map2(tacs, input,
+  mutate(delayFit = future_map2(tacs, input,
                          ~safe_onetcm(t_tac = .x$frame_mid, tac = .x$TAC,
                                  input = .y,
                                  weights = if(use_weights) .x$weights else NULL,
@@ -398,7 +412,8 @@ model_data <- model_data %>%
                                  k2.upper = 2,
                                  inpshift.upper = inpshift_upper,
                                  inpshift.lower = inpshift_lower,
-                                 multstart_iter = 5 ))) 
+                                 multstart_iter = 5 ),
+                         .options = furrr_options(seed = TRUE)))
 ```
 
 ```{r, eval=do_2tcm_singletac, echo=do_2tcm_singletac, results='asis'}
@@ -417,7 +432,7 @@ inpshift_upper <- config$FitDelay$inpshift_upper %||% 0.5
 safe_twotcm <- possibly(twotcm, otherwise = NA)
 
 model_data <- model_data %>%
-  mutate(delayFit = map2(tacs, input,
+  mutate(delayFit = future_map2(tacs, input,
                          ~safe_twotcm(t_tac = .x$frame_mid, tac = .x$TAC,
                                  input = .y,
                                  weights = if(use_weights) .x$weights else NULL,
@@ -427,7 +442,8 @@ model_data <- model_data %>%
                                  k2.upper = 2,
                                  inpshift.upper = inpshift_upper,
                                  inpshift.lower = inpshift_lower,
-                                 multstart_iter = 5 ))) 
+                                 multstart_iter = 5 ),
+                         .options = furrr_options(seed = TRUE)))
 ```
 
 ```{r, eval=do_1tcm_median, echo=do_1tcm_median, results='asis'}
@@ -446,7 +462,7 @@ inpshift_upper <- config$FitDelay$inpshift_upper %||% 0.5
 safe_onetcm <- possibly(onetcm, otherwise = NA)
 
 model_data <- model_data %>%
-  mutate(delayFit = map2(tacs, input,
+  mutate(delayFit = future_map2(tacs, input,
                          ~safe_onetcm(t_tac = .x$frame_mid, tac = .x$TAC,
                                  input = .y,
                                  weights = if(use_weights) .x$weights else NULL,
@@ -456,7 +472,8 @@ model_data <- model_data %>%
                                  k2.upper = 2,
                                  inpshift.upper = inpshift_upper,
                                  inpshift.lower = inpshift_lower,
-                                 multstart_iter = 5 ))) 
+                                 multstart_iter = 5 ),
+                         .options = furrr_options(seed = TRUE)))
 ```
 
 
@@ -477,7 +494,7 @@ inpshift_upper <- config$FitDelay$inpshift_upper %||% 0.5
 safe_twotcm <- possibly(twotcm, otherwise = NA)
 
 model_data <- model_data %>%
-  mutate(delayFit = map2(tacs, input,
+  mutate(delayFit = future_map2(tacs, input,
                          ~safe_twotcm(t_tac = .x$frame_mid, tac = .x$TAC,
                                  input = .y,
                                  weights = if(use_weights) .x$weights else NULL,
@@ -487,7 +504,8 @@ model_data <- model_data %>%
                                  k2.upper = 2,
                                  inpshift.upper = inpshift_upper,
                                  inpshift.lower = inpshift_lower,
-                                 multstart_iter = 5 ))) 
+                                 multstart_iter = 5 ),
+                         .options = furrr_options(seed = TRUE)))
 ```
 
 ### Extract results
@@ -550,19 +568,19 @@ walk2(model_data$delayFit, model_data$pet, ~print(plot(.x) +
 
 ```{r, eval=do_1tcm_median, echo=do_1tcm_median}
 # fit again with new delay
-fit_again_with_newdelay <- model_data %>% 
-  select(-delayFit) %>% 
-  inner_join(delay_out) %>% 
-  group_by(pet) %>% 
-  mutate(delayFit2 = pmap(list(tacs, input, inpshift),
-                         ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                 input = ..2, 
+fit_again_with_newdelay <- model_data %>%
+  select(-delayFit) %>%
+  inner_join(delay_out) %>%
+  mutate(delayFit2 = future_pmap(list(tacs, input, inpshift),
+                         ~safe_onetcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                 input = ..2,
                                  weights = if(use_weights) ..1$weights else NULL,
                                  vB =  if(fit_vB) vB_value else NULL,
-                                 timeStartEnd = c(0,time_window), 
+                                 timeStartEnd = c(0,time_window),
                                  K1.upper = 2,
                                  k2.upper = 2,
-                                 inpshift = ..3))) %>% 
+                                 inpshift = ..3),
+                         .options = furrr_options(seed = TRUE))) %>%
   mutate(success =map_lgl(delayFit2, ~{
     if(is.list(.x)) TRUE else FALSE} )) %>% 
   filter(success)
@@ -613,19 +631,19 @@ pwalk(list(tacs_refits$tacs, tacs_refits$preds, tacs_refits$input,
 
 ```{r, eval=do_2tcm_median, echo=do_2tcm_median}
 # fit again with new delay
-fit_again_with_newdelay <- model_data %>% 
-  select(-delayFit) %>% 
-  inner_join(delay_out) %>% 
-  group_by(pet) %>% 
-  mutate(delayFit2 = pmap(list(tacs, input, inpshift),
-                         ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC, 
-                                 input = ..2, 
+fit_again_with_newdelay <- model_data %>%
+  select(-delayFit) %>%
+  inner_join(delay_out) %>%
+  mutate(delayFit2 = future_pmap(list(tacs, input, inpshift),
+                         ~safe_twotcm(t_tac = ..1$frame_mid, tac = ..1$TAC,
+                                 input = ..2,
                                  weights = if(use_weights) ..1$weights else NULL,
                                  vB =  if(fit_vB) vB_value else NULL,
-                                 timeStartEnd = c(0,time_window), 
+                                 timeStartEnd = c(0,time_window),
                                  K1.upper = 2,
                                  k2.upper = 2,
-                                 inpshift = ..3))) %>% 
+                                 inpshift = ..3),
+                         .options = furrr_options(seed = TRUE))) %>%
   mutate(success =map_lgl(delayFit2, ~{
     if(is.list(.x)) TRUE else FALSE} )) %>% 
   filter(success)
@@ -751,6 +769,10 @@ walk2(delay_out$inpshift,
       save_inpshift)
 ```
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/logan_report.Rmd
+++ b/inst/rmd/logan_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 theme_set(theme_light())
 
@@ -480,7 +494,6 @@ if (!is.null(subset_config) && (!is.null(subset_config$start) || !is.null(subset
 safe_Loganplot <- possibly(Loganplot, otherwise = NA)
 
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_Logan = pmap(list(tacs, input, inpshift, vB),
                          ~safe_Loganplot(
                            t_tac = ..1$frame_mid,
@@ -623,28 +636,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_Logan, region, title), 
-                        ~plot(..1, roiname=..2) + 
-                          labs(title = ..3))) %>% 
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_Logan, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_Logan, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_Logan, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -778,6 +837,10 @@ walk2(savefits_pet$jsondat,
       ~writeLines(.x, .y))
 ```
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/ma1_report.Rmd
+++ b/inst/rmd/ma1_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 theme_set(theme_light())
 
@@ -474,7 +488,6 @@ if (!is.null(subset_config) && (!is.null(subset_config$start) || !is.null(subset
 safe_MA1 <- possibly(ma1, otherwise = NA)
 
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_MA1 = pmap(list(tacs, input, inpshift, vB),
                          ~safe_MA1(
                            t_tac = ..1$frame_mid,
@@ -615,30 +628,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_MA1, region, title), 
-                        ~plot(..1, roiname=..2) + 
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>% 
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_MA1, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_MA1, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_MA1, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -761,6 +818,10 @@ walk2(savefits_pet$jsondat,
       ~writeLines(.x, .y))
 ```
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/mrtm1_report.Rmd
+++ b/inst/rmd/mrtm1_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
+
 theme_set(theme_light())
 
 # Use parameters (from params or debugging section above)
@@ -253,7 +267,6 @@ safe_mrtm1 <- possibly(mrtm1, otherwise = NA)
 
 # Fit MRTM1 model to all regional TACs
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_mrtm1 = map(tacs,
                          ~safe_mrtm1(t_tac = .x$frame_mid,
                                     reftac = .x$RefTAC,
@@ -394,30 +407,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(fitplot = pmap(list(fit_mrtm1, region, title),
-                        ~plot(..1, roiname=..2) +
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>%
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_mrtm1, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(resplot = pmap(list(fit_mrtm1, title),
-                        ~plot_residuals(..1) +
-                          labs(title = ..2))) %>%
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_mrtm1, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -544,6 +601,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/mrtm2_report.Rmd
+++ b/inst/rmd/mrtm2_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
+
 theme_set(theme_light())
 
 # Use parameters (from params or debugging section above)
@@ -365,7 +379,6 @@ safe_mrtm2 <- possibly(mrtm2, otherwise = NA)
 
 # Fit MRTM2 model to all regional TACs
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_mrtm2 = pmap(list(tacs, k2prime),
                          ~safe_mrtm2(t_tac = ..1$frame_mid,
                                     reftac = ..1$RefTAC,
@@ -508,30 +521,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(fitplot = pmap(list(fit_mrtm2, region, title),
-                        ~plot(..1, roiname=..2) +
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>%
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_mrtm2, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(resplot = pmap(list(fit_mrtm2, title),
-                        ~plot_residuals(..1) +
-                          labs(title = ..2))) %>%
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_mrtm2, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -666,6 +723,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/patlak_report.Rmd
+++ b/inst/rmd/patlak_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 theme_set(theme_light())
 
@@ -480,7 +494,6 @@ if (!is.null(subset_config) && (!is.null(subset_config$start) || !is.null(subset
 safe_Patlakplot <- possibly(Patlakplot, otherwise = NA)
 
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_Patlak = pmap(list(tacs, input, inpshift, vB),
                          ~safe_Patlakplot(
                            t_tac = ..1$frame_mid,
@@ -622,28 +635,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(fitplot = pmap(list(fit_Patlak, region, title), 
-                        ~plot_Patlakfit(..1, roiname=..2) + 
-                          labs(title = ..3))) %>% 
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_Patlak, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot_Patlakfit(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>% 
-  mutate(title = paste(pet, " : ", region)) %>% 
-  mutate(resplot = pmap(list(fit_Patlak, title), 
-                        ~plot_residuals(..1) + 
-                          labs(title = ..2))) %>% 
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_Patlak, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -776,6 +835,10 @@ walk2(savefits_pet$jsondat,
       ~writeLines(.x, .y))
 ```
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/reference_tac_report.Rmd
+++ b/inst/rmd/reference_tac_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   analysis_folder: NULL
   bids_dir: NULL
   blood_dir: NULL
@@ -23,6 +24,18 @@ library(plotly)
 library(crosstalk)
 library(htmltools)
 library(scales)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 theme_set(theme_light())
 
@@ -455,26 +468,30 @@ weights_data <- tibble(
   unnest(tacs) %>%
   select(-basename, -measurement, -desc, -TAC, -filename)
 
-ref_tac_data_noisecalc <- ref_tac_data %>% 
-  inner_join(weights_data) %>% 
+ref_tac_data_noisecalc <- ref_tac_data %>%
+  inner_join(weights_data) %>%
   group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
                                            "run", "pet", "filename")))) %>%
-  nest(.key = "ref_tacs") %>% 
-  mutate(splinefit = map(ref_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
+  nest(.key = "ref_tacs") %>%
+  ungroup() %>%
+  mutate(splinefit = future_map(ref_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
                                                tac     = .x$RefTAC,
-                                               weights = .x$weights))) %>% 
-  mutate(RSS = map_dbl(splinefit, ~sum((weights(.x)/mean(weights(.x))) * 
+                                               weights = .x$weights),
+                                .options = furrr_options(seed = TRUE))) %>%
+  mutate(RSS = map_dbl(splinefit, ~sum((weights(.x)/mean(weights(.x))) *
                                          (.x$tacs$TAC_fitted - .x$tacs$TAC)^2)))
 
-target_tac_data_noisecalc <- target_tac_data %>% 
-  inner_join(weights_data) %>% 
+target_tac_data_noisecalc <- target_tac_data %>%
+  inner_join(weights_data) %>%
   group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
                                            "run", "pet", "filename", "region")))) %>%
-  nest(.key = "target_tacs") %>% 
-  mutate(splinefit = map(target_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
+  nest(.key = "target_tacs") %>%
+  ungroup() %>%
+  mutate(splinefit = future_map(target_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
                                                   tac     = .x$TAC,
-                                                  weights = .x$weights))) %>% 
-  mutate(RSS = map_dbl(splinefit, ~sum((weights(.x)/mean(weights(.x))) * 
+                                                  weights = .x$weights),
+                                .options = furrr_options(seed = TRUE))) %>%
+  mutate(RSS = map_dbl(splinefit, ~sum((weights(.x)/mean(weights(.x))) *
                                          (.x$tacs$TAC_fitted - .x$tacs$TAC)^2)))
 
 RSS_compare <- ref_tac_data_noisecalc %>% 
@@ -506,12 +523,14 @@ ref_tac_fitdata <- ref_tac_data %>%
   inner_join(ref_weights_final) %>%
   group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
                                            "run", "pet", "tac_filename")))) %>%
-  nest(.key = "ref_tacs") 
+  nest(.key = "ref_tacs") %>%
+  ungroup()
 
 ref_tac_fitdata <- ref_tac_fitdata %>%
-  mutate(ref_fit = map(ref_tacs, ~feng_1tc_tac(t_tac   = .x$frame_mid/60,
+  mutate(ref_fit = future_map(ref_tacs, ~feng_1tc_tac(t_tac   = .x$frame_mid/60,
                                               tac     = .x$RefTAC,
-                                              weights = .x$ref_weights)))
+                                              weights = .x$ref_weights),
+                              .options = furrr_options(seed = TRUE)))
 
 ref_tac_preddata <- ref_tac_fitdata %>%
   mutate(ref_preds = map(ref_fit, ~.x$tacs %>%
@@ -617,12 +636,14 @@ ref_tac_fitdata <- ref_tac_data %>%
   inner_join(ref_weights_final) %>%
   group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
                                            "run", "pet", "tac_filename")))) %>%
-  nest(.key = "ref_tacs") 
+  nest(.key = "ref_tacs") %>%
+  ungroup()
 
 ref_tac_fitdata <- ref_tac_fitdata %>%
-  mutate(ref_fit = map(ref_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
+  mutate(ref_fit = future_map(ref_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
                                               tac     = .x$RefTAC,
-                                              weights = .x$ref_weights)))
+                                              weights = .x$ref_weights),
+                              .options = furrr_options(seed = TRUE)))
 
 ref_tac_preddata <- ref_tac_fitdata %>%
   mutate(ref_preds = map(ref_fit, ~.x$tacs %>%
@@ -756,6 +777,10 @@ target_tac_files %>%
     write_tsv(.x,
               file = paste0(analysis_folder, "/", target_filename))
   })
+```
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
 ```
 
 ---

--- a/inst/rmd/reflogan_report.Rmd
+++ b/inst/rmd/reflogan_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
+
 theme_set(theme_light())
 
 # Use parameters (from params or debugging section above)
@@ -380,7 +394,6 @@ safe_refLogan <- possibly(refLogan, otherwise = NA)
 
 # Fit refLogan model to all regional TACs
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
   mutate(fit_refLogan = pmap(list(tacs, k2prime),
                          ~safe_refLogan(t_tac = ..1$frame_mid,
                                     reftac = ..1$RefTAC,
@@ -522,28 +535,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 The refLogan model uses a graphical analysis approach. The plots below show the Logan plot space with transformed coordinates, where the slope represents the distribution volume ratio (DVR = BP + 1).
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(fitplot = pmap(list(fit_refLogan, region, title),
-                        ~plot(..1, roiname=..2) +
-                          labs(title = ..3))) %>%
-  pull(fitplot)
+```{r fit-plots, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_refLogan, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(resplot = pmap(list(fit_refLogan, title),
-                        ~plot_residuals(..1) +
-                          labs(title = ..2))) %>%
-  pull(resplot)
+```{r residual-plots, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_refLogan, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -691,6 +750,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/srtm2_report.Rmd
+++ b/inst/rmd/srtm2_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,7 +22,20 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
+
 theme_set(theme_light())
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
 
 # Use parameters (from params or debugging section above)
 analysis_folder <- params$analysis_folder %||% analysis_folder
@@ -370,8 +384,7 @@ safe_srtm2 <- possibly(srtm2, otherwise = NA)
 
 # Fit SRTM2 model to all regional TACs
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
-  mutate(fit_srtm2 = pmap(list(tacs, k2prime),
+  mutate(fit_srtm2 = future_pmap(list(tacs, k2prime),
                          ~safe_srtm2(t_tac = ..1$frame_mid,
                                     reftac = ..1$RefTAC,
                                     roitac = ..1$TAC,
@@ -385,7 +398,8 @@ model_data <- model_data %>%
                                     bp.start = bp_start,
                                     bp.lower = bp_lower,
                                     bp.upper = bp_upper,
-                                    multstart_iter = multstart_iter))) %>%
+                                    multstart_iter = multstart_iter),
+                         .options = furrr_options(seed = TRUE))) %>%
   ungroup() %>%
   mutate(success = map_dbl(fit_srtm2, length) > 1)
 ```
@@ -515,30 +529,74 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(fitplot = pmap(list(fit_srtm2, region, title),
-                        ~plot(..1, roiname=..2) +
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>%
-  pull(fitplot)
+```{r, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_srtm2, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(resplot = pmap(list(fit_srtm2, title),
-                        ~plot_residuals(..1) +
-                          labs(title = ..2))) %>%
-  pull(resplot)
+```{r, results='asis'}
+n_res_plots <- nrow(model_data %>% filter(success))
+embed_res_plots <- n_res_plots <= 200
 
-walk(resplots, ~print(.x))
+if (embed_res_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_srtm2, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_res_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_res_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -666,6 +724,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/srtm_report.Rmd
+++ b/inst/rmd/srtm_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   model_number: "Model 1"
   analysis_folder: NULL
   bids_dir: NULL
@@ -21,6 +22,19 @@ library(knitr)
 library(jsonlite)
 library(glue)
 library(DT)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
+
 theme_set(theme_light())
 
 # Use parameters (from params or debugging section above)
@@ -261,8 +275,7 @@ safe_srtm <- possibly(srtm, otherwise = NA)
 
 # Fit SRTM model to all regional TACs
 model_data <- model_data %>%
-  group_by(output_stem, region) %>%
-  mutate(fit_srtm = map(tacs,
+  mutate(fit_srtm = future_map(tacs,
                          ~safe_srtm(t_tac = .x$frame_mid,
                                     reftac = .x$RefTAC,
                                     roitac = .x$TAC,
@@ -278,8 +291,8 @@ model_data <- model_data %>%
                                     bp.start = bp_start,
                                     bp.lower = bp_lower,
                                     bp.upper = bp_upper,
-                                    multstart_iter = multstart_iter))) %>%
-  ungroup() %>%
+                                    multstart_iter = multstart_iter),
+                         .options = furrr_options(seed = TRUE))) %>%
   mutate(success = map_dbl(fit_srtm, length) > 1)
 ```
 
@@ -406,30 +419,71 @@ ggplot(par_table_long, aes(x=Value, fill=region)) +
 
 ### Plots
 
-```{r, fig.height=4, fig.width=6}
-fitplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(fitplot = pmap(list(fit_srtm, region, title),
-                        ~plot(..1, roiname=..2) +
-                          labs(title = ..3,
-                               y = "Radioactivity (kBq)",
-                               x = "Time (min)"))) %>%
-  pull(fitplot)
+```{r, results='asis'}
+n_fit_plots <- nrow(model_data %>% filter(success))
+embed_fit_plots <- n_fit_plots <= 200
 
-walk(fitplots, ~print(.x))
+if (embed_fit_plots) {
+  fit_plot_dir <- tempdir()
+} else {
+  fit_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "fit")
+  dir.create(fit_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
+
+fit_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_srtm, .$region, .$title, .$safe_filename),
+    function(fit, region, title, fname) {
+      p <- plot(fit, roiname = region) +
+        labs(title = title, y = "Radioactivity (kBq)", x = "Time (min)")
+      filepath <- file.path(fit_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(fit_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} fit plots saved to: `reports/{desc}_report_plots/fit/`\n\n"))
+}
 ```
 
 ### Residuals
 
-```{r, fig.height=4, fig.width=6}
-resplots <- model_data %>%
-  mutate(title = paste(pet, " : ", region)) %>%
-  mutate(resplot = pmap(list(fit_srtm, title),
-                        ~plot_residuals(..1) +
-                          labs(title = ..2))) %>%
-  pull(resplot)
+```{r, results='asis'}
+if (embed_fit_plots) {
+  res_plot_dir <- tempdir()
+} else {
+  res_plot_dir <- file.path(analysis_folder, "reports",
+                        paste0(desc, "_report_plots"), "residuals")
+  dir.create(res_plot_dir, recursive = TRUE, showWarnings = FALSE)
+}
 
-walk(resplots, ~print(.x))
+res_plot_files <- model_data %>%
+  filter(success) %>%
+  mutate(title = paste(pet, " : ", region),
+         safe_filename = str_replace_all(
+           paste(pet, region, sep = "_"), "[^A-Za-z0-9_-]", "_")) %>%
+  {future_pmap_chr(
+    list(.$fit_srtm, .$title, .$safe_filename),
+    function(fit, title, fname) {
+      p <- plot_residuals(fit) +
+        labs(title = title)
+      filepath <- file.path(res_plot_dir, paste0(fname, ".png"))
+      ggsave(filepath, p, width = 6, height = 4, dpi = 96)
+      filepath
+    }, .options = furrr_options(seed = TRUE))}
+
+if (embed_fit_plots) {
+  walk(res_plot_files, ~cat("![](", .x, ")\n\n", sep = ""))
+} else {
+  cat(str_glue("\n\n**Note:** {n_fit_plots} residual plots saved to: `reports/{desc}_report_plots/residuals/`\n\n"))
+}
 ```
 
 
@@ -548,6 +602,10 @@ walk2(savefits_pet$jsondat,
 
 
 
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
 
 # Session Information
 

--- a/inst/rmd/tstar_finder_report.Rmd
+++ b/inst/rmd/tstar_finder_report.Rmd
@@ -6,10 +6,11 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   analysis_folder: NULL
   bids_dir: NULL
   blood_dir: NULL
-  tstar_results: NULL  
+  tstar_results: NULL
   binding_regions: NULL
 ---
 

--- a/inst/rmd/weights_report.Rmd
+++ b/inst/rmd/weights_report.Rmd
@@ -7,6 +7,7 @@ output:
     toc_depth: 2
     code_folding: hide
 params:
+  cores: 1
   analysis_folder: NULL
   bids_dir: NULL
   blood_dir: NULL

--- a/singularity/run-automatic.sh
+++ b/singularity/run-automatic.sh
@@ -13,6 +13,7 @@ BLOOD_DIR=""
 STEP=""
 PETFIT_FOLDER="petfit"
 ANALYSIS_FOLDER="Primary_Analysis"
+CORES=1
 
 # Help function
 show_help() {
@@ -29,6 +30,7 @@ Options:
     --step STEP              Specific step to run (optional)
     --petfit-folder NAME    Name for petfit output folder (default: $PETFIT_FOLDER)
     --analysis-folder NAME   Name for analysis subfolder (default: $ANALYSIS_FOLDER)
+    --cores N                Number of cores for parallel processing (default: $CORES)
     -h, --help               Show this help message
 
 Step Options:
@@ -100,6 +102,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --analysis-folder)
             ANALYSIS_FOLDER="$2"
+            shift 2
+            ;;
+        --cores)
+            CORES="$2"
             shift 2
             ;;
         -h|--help)
@@ -194,6 +200,7 @@ fi
 if [ -n "$ANALYSIS_FOLDER" ]; then
     CMD_ARGS="$CMD_ARGS --analysis_foldername $ANALYSIS_FOLDER"
 fi
+CMD_ARGS="$CMD_ARGS --cores $CORES"
 
 echo "=== petfit Singularity Automatic Mode ==="
 echo "Container: $CONTAINER"

--- a/singularity/run-interactive.sh
+++ b/singularity/run-interactive.sh
@@ -15,6 +15,7 @@ DERIVATIVES_DIR=""
 BLOOD_DIR=""
 PETFIT_FOLDER="petfit"
 ANALYSIS_FOLDER="Primary_Analysis"
+CORES=1
 
 # Help function
 show_help() {
@@ -33,6 +34,7 @@ Options:
     --blood-dir PATH        Path to blood data directory to mount
     --petfit-folder NAME   Name for petfit output folder (default: $PETFIT_FOLDER)
     --analysis-folder NAME  Name for analysis subfolder (default: $ANALYSIS_FOLDER)
+    --cores N               Number of cores for parallel processing (default: $CORES)
     -h, --help              Show this help message
 
 Examples:
@@ -96,6 +98,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --analysis-folder)
             ANALYSIS_FOLDER="$2"
+            shift 2
+            ;;
+        --cores)
+            CORES="$2"
             shift 2
             ;;
         -h|--help)
@@ -167,6 +173,7 @@ fi
 if [ -n "$ANALYSIS_FOLDER" ]; then
     CMD_ARGS="$CMD_ARGS --analysis_foldername $ANALYSIS_FOLDER"
 fi
+CMD_ARGS="$CMD_ARGS --cores $CORES"
 
 echo "=== petfit Singularity Interactive Mode ==="
 echo "Container: $CONTAINER"

--- a/tests/testthat/helper-integration.R
+++ b/tests/testthat/helper-integration.R
@@ -308,7 +308,8 @@ setup_modelling_config <- function(workspace_info, config_fixture_name,
 run_petfit_docker <- function(func, mode, workspace_info,
                               blood_dir = NULL, step = NULL,
                               image = "mathesong/petfit:latest",
-                              analysis_foldername = "Primary_Analysis") {
+                              analysis_foldername = "Primary_Analysis",
+                              cores = 1L) {
   # Build volume mounts
   volumes <- c(
     paste0(workspace_info$bids_dir, ":/data/bids_dir:ro"),
@@ -331,6 +332,9 @@ run_petfit_docker <- function(func, mode, workspace_info,
   docker_args <- c(docker_args, "--analysis_foldername", analysis_foldername)
   if (!is.null(step)) {
     docker_args <- c(docker_args, "--step", step)
+  }
+  if (cores > 1L) {
+    docker_args <- c(docker_args, "--cores", as.character(cores))
   }
 
   result <- system2("docker", docker_args, stdout = TRUE, stderr = TRUE)
@@ -355,7 +359,8 @@ run_petfit_docker <- function(func, mode, workspace_info,
 run_petfit_singularity <- function(func, mode, workspace_info,
                                    container = "petfit_latest.sif",
                                    blood_dir = NULL, step = NULL,
-                                   analysis_foldername = "Primary_Analysis") {
+                                   analysis_foldername = "Primary_Analysis",
+                                   cores = 1L) {
   # Detect whether to use singularity or apptainer command
   cmd <- if (nchar(Sys.which("apptainer")) > 0) "apptainer" else "singularity"
 
@@ -379,6 +384,9 @@ run_petfit_singularity <- function(func, mode, workspace_info,
   if (!is.null(step)) {
     cmd_args <- c(cmd_args, "--step", step)
   }
+  if (cores > 1L) {
+    cmd_args <- c(cmd_args, "--cores", as.character(cores))
+  }
 
   result <- system2(cmd, cmd_args, stdout = TRUE, stderr = TRUE)
   exit_code <- attr(result, "status") %||% 0L
@@ -387,4 +395,109 @@ run_petfit_singularity <- function(func, mode, workspace_info,
     output = result,
     exit_code = exit_code
   )
+}
+
+# ---------------------------------------------------------------------------
+# Docker container helpers
+# ---------------------------------------------------------------------------
+
+DOCKER_IMAGE <- "mathesong/petfit:latest"
+
+#' Ensure Docker image is available (build or pull if needed)
+ensure_docker_image <- function() {
+  # Optionally rebuild the image from source
+  if (Sys.getenv("PETFIT_DOCKER_BUILD") == "true") {
+    pkg_root <- testthat::test_path("..", "..")
+    build_result <- system2(
+      "docker",
+      c("build", "-t", DOCKER_IMAGE, "-f", "docker/Dockerfile", "."),
+      stdout = TRUE, stderr = TRUE,
+      env = paste0("DOCKER_BUILDKIT=1")
+    )
+    exit_code <- attr(build_result, "status") %||% 0L
+    if (exit_code != 0L) {
+      testthat::skip(paste("Docker build failed:", paste(build_result, collapse = "\n")))
+    }
+  }
+
+  # Verify image exists
+  check <- system2("docker", c("image", "inspect", DOCKER_IMAGE),
+                    stdout = FALSE, stderr = FALSE)
+  if (check != 0L) {
+    testthat::skip(paste("Docker image not available:", DOCKER_IMAGE,
+                         "\nPull with: docker pull", DOCKER_IMAGE,
+                         "\nOr set PETFIT_DOCKER_BUILD=true to build from source"))
+  }
+}
+
+#' Set up workspace for Docker tests (resolves symlinks)
+setup_docker_workspace <- function() {
+  dataset_dir <- ensure_testdata()
+  ws <- create_integration_workspace(dataset_dir)
+
+  # Docker needs real paths, not symlinks -- resolve the petprep symlink
+  petprep_link <- file.path(ws$derivatives_dir, "petprep")
+  if (file.exists(petprep_link) && Sys.readlink(petprep_link) != "") {
+    real_path <- normalizePath(petprep_link)
+    unlink(petprep_link)
+    system2("cp", c("-a", real_path, petprep_link))
+  }
+
+  ws
+}
+
+# ---------------------------------------------------------------------------
+# Singularity/Apptainer container helpers
+# ---------------------------------------------------------------------------
+
+#' Locate singularity/apptainer command
+get_singularity_cmd <- function() {
+  if (nchar(Sys.which("apptainer")) > 0) return("apptainer")
+  if (nchar(Sys.which("singularity")) > 0) return("singularity")
+  NULL
+}
+
+#' Find or build Singularity container image
+find_singularity_container <- function() {
+  # Check for explicit path
+  sif_path <- Sys.getenv("PETFIT_SINGULARITY_SIF", unset = "")
+  if (sif_path != "" && file.exists(sif_path)) {
+    return(sif_path)
+  }
+
+  # Check for a SIF in the singularity/ directory
+  pkg_root <- testthat::test_path("..", "..")
+  sif_candidates <- list.files(
+    file.path(pkg_root, "singularity"),
+    pattern = "\\.sif$",
+    full.names = TRUE
+  )
+  if (length(sif_candidates) > 0) {
+    return(sif_candidates[1])
+  }
+
+  # Try docker-daemon reference if Docker image exists
+  docker_check <- system2("docker", c("image", "inspect", "mathesong/petfit:latest"),
+                          stdout = FALSE, stderr = FALSE)
+  if (docker_check == 0L) {
+    return("docker-daemon://mathesong/petfit:latest")
+  }
+
+  NULL
+}
+
+#' Set up workspace for Singularity tests (resolves symlinks)
+setup_singularity_workspace <- function() {
+  dataset_dir <- ensure_testdata()
+  ws <- create_integration_workspace(dataset_dir)
+
+  # Singularity needs real paths for bind mounts
+  petprep_link <- file.path(ws$derivatives_dir, "petprep")
+  if (file.exists(petprep_link) && Sys.readlink(petprep_link) != "") {
+    real_path <- normalizePath(petprep_link)
+    unlink(petprep_link)
+    system2("cp", c("-a", real_path, petprep_link))
+  }
+
+  ws
 }

--- a/tests/testthat/helper-integration.R
+++ b/tests/testthat/helper-integration.R
@@ -487,7 +487,7 @@ find_singularity_container <- function() {
   docker_check <- system2("docker", c("image", "inspect", "mathesong/petfit:latest"),
                           stdout = FALSE, stderr = FALSE)
   if (docker_check == 0L) {
-    return("docker-daemon://mathesong/petfit:latest")
+    return("docker-daemon:mathesong/petfit:latest")
   }
 
   NULL

--- a/tests/testthat/test-integration-docker.R
+++ b/tests/testthat/test-integration-docker.R
@@ -233,7 +233,9 @@ test_that("Docker: invalid --func argument fails gracefully", {
     "--mode", "automatic"
   )
 
-  output <- system2("docker", docker_args, stdout = TRUE, stderr = TRUE)
+  output <- suppressWarnings(
+    system2("docker", docker_args, stdout = TRUE, stderr = TRUE)
+  )
   exit_code <- attr(output, "status") %||% 0L
 
   expect_true(exit_code != 0L,

--- a/tests/testthat/test-integration-docker.R
+++ b/tests/testthat/test-integration-docker.R
@@ -9,59 +9,6 @@
 # Requires: PETFIT_INTEGRATION_TESTS=true, PETFIT_DOCKER_TESTS=true, Docker
 
 # ---------------------------------------------------------------------------
-# Helper: ensure Docker image is available
-# ---------------------------------------------------------------------------
-
-DOCKER_IMAGE <- "mathesong/petfit:latest"
-
-ensure_docker_image <- function() {
-  # Optionally rebuild the image from source
-  if (Sys.getenv("PETFIT_DOCKER_BUILD") == "true") {
-    pkg_root <- testthat::test_path("..", "..")
-    build_result <- system2(
-      "docker",
-      c("build", "-t", DOCKER_IMAGE, "-f", "docker/Dockerfile", "."),
-      stdout = TRUE, stderr = TRUE,
-      env = paste0("DOCKER_BUILDKIT=1")
-    )
-    exit_code <- attr(build_result, "status") %||% 0L
-    if (exit_code != 0L) {
-      testthat::skip(paste("Docker build failed:", paste(build_result, collapse = "\n")))
-    }
-  }
-
-  # Verify image exists
-  check <- system2("docker", c("image", "inspect", DOCKER_IMAGE),
-                    stdout = FALSE, stderr = FALSE)
-  if (check != 0L) {
-    testthat::skip(paste("Docker image not available:", DOCKER_IMAGE,
-                         "\nPull with: docker pull", DOCKER_IMAGE,
-                         "\nOr set PETFIT_DOCKER_BUILD=true to build from source"))
-  }
-}
-
-# ---------------------------------------------------------------------------
-# Helper: set up workspace for Docker tests (resolves symlinks)
-# ---------------------------------------------------------------------------
-
-setup_docker_workspace <- function() {
-  dataset_dir <- ensure_testdata()
-  ws <- create_integration_workspace(dataset_dir)
-
-  # Docker needs real paths, not symlinks -- resolve the petprep symlink
-  petprep_link <- file.path(ws$derivatives_dir, "petprep")
-  if (file.exists(petprep_link) && Sys.readlink(petprep_link) != "") {
-    real_path <- normalizePath(petprep_link)
-    unlink(petprep_link)
-    # Copy petprep into workspace so Docker can access it via bind mount
-    # Use system cp for speed with -a to preserve structure
-    system2("cp", c("-a", real_path, petprep_link))
-  }
-
-  ws
-}
-
-# ---------------------------------------------------------------------------
 # Regiondef: automatic mode
 # ---------------------------------------------------------------------------
 

--- a/tests/testthat/test-integration-parallel-docker.R
+++ b/tests/testthat/test-integration-parallel-docker.R
@@ -92,7 +92,7 @@ test_that("Docker: plasma modelling with cores=2 succeeds", {
 
   report_files <- list.files(reports_dir, pattern = "\\.html$")
   expect_gt(length(report_files), 0,
-            info = "At least one HTML report should be generated with cores=2")
+            label = "At least one HTML report should be generated with cores=2")
 })
 
 # ---------------------------------------------------------------------------
@@ -139,5 +139,5 @@ test_that("Docker: reference modelling with cores=2 succeeds", {
 
   report_files <- list.files(reports_dir, pattern = "\\.html$")
   expect_gt(length(report_files), 0,
-            info = "At least one HTML report should be generated with cores=2")
+            label = "At least one HTML report should be generated with cores=2")
 })

--- a/tests/testthat/test-integration-parallel-docker.R
+++ b/tests/testthat/test-integration-parallel-docker.R
@@ -1,0 +1,143 @@
+# Integration tests: Parallel Processing via Docker Container
+#
+# Tests that the --cores flag works correctly when passed through Docker.
+# Verifies that parallel processing with cores=2 produces valid output
+# from within a Docker container.
+#
+# Requires: PETFIT_INTEGRATION_TESTS=true AND PETFIT_DOCKER_TESTS=true
+#   AND PETFIT_PARALLEL_TESTS=true
+
+# ---------------------------------------------------------------------------
+# Skip helper
+# ---------------------------------------------------------------------------
+
+skip_if_no_parallel_docker <- function() {
+  skip_if_no_docker()
+  if (!identical(Sys.getenv("PETFIT_PARALLEL_TESTS"), "true")) {
+    testthat::skip("Parallel tests disabled (set PETFIT_PARALLEL_TESTS=true)")
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Test: Docker regiondef with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Docker: regiondef with cores=2 produces combined TACs", {
+  skip_if_no_parallel_docker()
+  ensure_docker_image()
+
+  ws <- setup_docker_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  result <- run_petfit_docker(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Docker parallel regiondef failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify output files were created
+  petfit_dir <- file.path(ws$derivatives_dir, "petfit")
+  combined_tacs <- file.path(petfit_dir, "desc-combinedregions_tacs.tsv")
+  expect_true(file.exists(combined_tacs),
+              info = "Combined TACs file should be created with cores=2")
+})
+
+# ---------------------------------------------------------------------------
+# Test: Docker plasma pipeline with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Docker: plasma modelling with cores=2 succeeds", {
+  skip_if_no_parallel_docker()
+  ensure_docker_image()
+
+  ws <- setup_docker_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  # Run regiondef first (sequential is fine for setup)
+  regiondef_result <- run_petfit_docker(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws
+  )
+  if (regiondef_result$exit_code != 0L) {
+    testthat::skip("Docker regiondef prerequisite failed")
+  }
+
+  # Install plasma config
+  setup_modelling_config(ws, "ds004869_plasma_config.json")
+
+  # Run full plasma pipeline with 2 cores
+  result <- run_petfit_docker(
+    func = "modelling_plasma",
+    mode = "automatic",
+    workspace_info = ws,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Docker parallel plasma pipeline failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  expect_true(dir.exists(reports_dir), info = "Reports directory should exist")
+
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+  expect_gt(length(report_files), 0,
+            info = "At least one HTML report should be generated with cores=2")
+})
+
+# ---------------------------------------------------------------------------
+# Test: Docker reference pipeline with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Docker: reference modelling with cores=2 succeeds", {
+  skip_if_no_parallel_docker()
+  ensure_docker_image()
+
+  ws <- setup_docker_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  # Run regiondef first
+  regiondef_result <- run_petfit_docker(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws
+  )
+  if (regiondef_result$exit_code != 0L) {
+    testthat::skip("Docker regiondef prerequisite failed")
+  }
+
+  # Install ref config
+  setup_modelling_config(ws, "ds004869_ref_config.json")
+
+  # Run full reference pipeline with 2 cores
+  result <- run_petfit_docker(
+    func = "modelling_ref",
+    mode = "automatic",
+    workspace_info = ws,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Docker parallel reference pipeline failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  expect_true(dir.exists(reports_dir), info = "Reports directory should exist")
+
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+  expect_gt(length(report_files), 0,
+            info = "At least one HTML report should be generated with cores=2")
+})

--- a/tests/testthat/test-integration-parallel-singularity.R
+++ b/tests/testthat/test-integration-parallel-singularity.R
@@ -103,7 +103,7 @@ test_that("Singularity: plasma modelling with cores=2 succeeds", {
 
   report_files <- list.files(reports_dir, pattern = "\\.html$")
   expect_gt(length(report_files), 0,
-            info = "At least one HTML report should be generated with cores=2")
+            label = "At least one HTML report should be generated with cores=2")
 })
 
 # ---------------------------------------------------------------------------
@@ -156,5 +156,5 @@ test_that("Singularity: reference modelling with cores=2 succeeds", {
 
   report_files <- list.files(reports_dir, pattern = "\\.html$")
   expect_gt(length(report_files), 0,
-            info = "At least one HTML report should be generated with cores=2")
+            label = "At least one HTML report should be generated with cores=2")
 })

--- a/tests/testthat/test-integration-parallel-singularity.R
+++ b/tests/testthat/test-integration-parallel-singularity.R
@@ -1,0 +1,160 @@
+# Integration tests: Parallel Processing via Singularity/Apptainer Container
+#
+# Tests that the --cores flag works correctly when passed through Singularity.
+# Verifies that parallel processing with cores=2 produces valid output
+# from within a Singularity/Apptainer container.
+#
+# Requires: PETFIT_INTEGRATION_TESTS=true AND PETFIT_SINGULARITY_TESTS=true
+#   AND PETFIT_PARALLEL_TESTS=true
+
+# ---------------------------------------------------------------------------
+# Skip helper
+# ---------------------------------------------------------------------------
+
+skip_if_no_parallel_singularity <- function() {
+  skip_if_no_singularity()
+  if (!identical(Sys.getenv("PETFIT_PARALLEL_TESTS"), "true")) {
+    testthat::skip("Parallel tests disabled (set PETFIT_PARALLEL_TESTS=true)")
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Test: Singularity regiondef with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Singularity: regiondef with cores=2 produces combined TACs", {
+  skip_if_no_parallel_singularity()
+
+  container <- find_singularity_container()
+  if (is.null(container)) {
+    testthat::skip("No Singularity container available")
+  }
+
+  ws <- setup_singularity_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  result <- run_petfit_singularity(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws,
+    container = container,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Singularity parallel regiondef failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify output files were created
+  petfit_dir <- file.path(ws$derivatives_dir, "petfit")
+  combined_tacs <- file.path(petfit_dir, "desc-combinedregions_tacs.tsv")
+  expect_true(file.exists(combined_tacs),
+              info = "Combined TACs file should be created with cores=2")
+})
+
+# ---------------------------------------------------------------------------
+# Test: Singularity plasma pipeline with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Singularity: plasma modelling with cores=2 succeeds", {
+  skip_if_no_parallel_singularity()
+
+  container <- find_singularity_container()
+  if (is.null(container)) {
+    testthat::skip("No Singularity container available")
+  }
+
+  ws <- setup_singularity_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  # Run regiondef first
+  regiondef_result <- run_petfit_singularity(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws,
+    container = container
+  )
+  if (regiondef_result$exit_code != 0L) {
+    testthat::skip("Singularity regiondef prerequisite failed")
+  }
+
+  # Install plasma config
+  setup_modelling_config(ws, "ds004869_plasma_config.json")
+
+  # Run full plasma pipeline with 2 cores
+  result <- run_petfit_singularity(
+    func = "modelling_plasma",
+    mode = "automatic",
+    workspace_info = ws,
+    container = container,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Singularity parallel plasma pipeline failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  expect_true(dir.exists(reports_dir), info = "Reports directory should exist")
+
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+  expect_gt(length(report_files), 0,
+            info = "At least one HTML report should be generated with cores=2")
+})
+
+# ---------------------------------------------------------------------------
+# Test: Singularity reference pipeline with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("Singularity: reference modelling with cores=2 succeeds", {
+  skip_if_no_parallel_singularity()
+
+  container <- find_singularity_container()
+  if (is.null(container)) {
+    testthat::skip("No Singularity container available")
+  }
+
+  ws <- setup_singularity_workspace()
+  withr::defer(cleanup_workspace(ws))
+  setup_regiondef_config(ws)
+
+  # Run regiondef first
+  regiondef_result <- run_petfit_singularity(
+    func = "regiondef",
+    mode = "automatic",
+    workspace_info = ws,
+    container = container
+  )
+  if (regiondef_result$exit_code != 0L) {
+    testthat::skip("Singularity regiondef prerequisite failed")
+  }
+
+  # Install ref config
+  setup_modelling_config(ws, "ds004869_ref_config.json")
+
+  # Run full reference pipeline with 2 cores
+  result <- run_petfit_singularity(
+    func = "modelling_ref",
+    mode = "automatic",
+    workspace_info = ws,
+    container = container,
+    cores = 2L
+  )
+
+  expect_equal(result$exit_code, 0L,
+               info = paste("Singularity parallel reference pipeline failed:",
+                            paste(result$output, collapse = "\n")))
+
+  # Verify reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  expect_true(dir.exists(reports_dir), info = "Reports directory should exist")
+
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+  expect_gt(length(report_files), 0,
+            info = "At least one HTML report should be generated with cores=2")
+})

--- a/tests/testthat/test-integration-parallel.R
+++ b/tests/testthat/test-integration-parallel.R
@@ -1,0 +1,170 @@
+# Integration tests: Parallel Processing
+#
+# Tests that parallel processing with cores=2 produces identical results
+# to sequential processing (cores=1).
+#
+# Uses existing ds004869 test data (2 subjects).
+#
+# Requires: PETFIT_INTEGRATION_TESTS=true AND PETFIT_PARALLEL_TESTS=true
+
+# ---------------------------------------------------------------------------
+# Skip helper
+# ---------------------------------------------------------------------------
+
+skip_if_no_parallel <- function() {
+  skip_if_no_integration()
+  if (!identical(Sys.getenv("PETFIT_PARALLEL_TESTS"), "true")) {
+    testthat::skip("Parallel tests disabled (set PETFIT_PARALLEL_TESTS=true)")
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run regiondef + modelling setup for a given core count
+# ---------------------------------------------------------------------------
+
+setup_plasma_workspace_with_cores <- function(cores = 1L) {
+  dataset_dir <- ensure_testdata()
+  ws <- create_integration_workspace(dataset_dir)
+  setup_regiondef_config(ws)
+
+  regiondef_result <- petfit_regiondef_auto(
+    bids_dir = ws$bids_dir,
+    derivatives_dir = ws$derivatives_dir,
+    cores = cores
+  )
+
+  if (!regiondef_result$success) {
+    testthat::skip(paste("Regiondef failed:", paste(regiondef_result$messages, collapse = "\n")))
+  }
+
+  setup_modelling_config(ws, "ds004869_plasma_config.json")
+
+  ws
+}
+
+setup_ref_workspace_with_cores <- function(cores = 1L) {
+  dataset_dir <- ensure_testdata()
+  ws <- create_integration_workspace(dataset_dir)
+  setup_regiondef_config(ws)
+
+  regiondef_result <- petfit_regiondef_auto(
+    bids_dir = ws$bids_dir,
+    derivatives_dir = ws$derivatives_dir,
+    cores = cores
+  )
+
+  if (!regiondef_result$success) {
+    testthat::skip(paste("Regiondef failed:", paste(regiondef_result$messages, collapse = "\n")))
+  }
+
+  setup_modelling_config(ws, "ds004869_ref_config.json")
+
+  ws
+}
+
+# ---------------------------------------------------------------------------
+# Test: Parallel regiondef produces identical combined TACs
+# ---------------------------------------------------------------------------
+
+test_that("parallel regiondef produces identical output to sequential", {
+  skip_if_no_parallel()
+
+  dataset_dir <- ensure_testdata()
+
+  # Sequential
+  ws_seq <- create_integration_workspace(dataset_dir)
+  withr::defer(cleanup_workspace(ws_seq))
+  setup_regiondef_config(ws_seq)
+
+  result_seq <- petfit_regiondef_auto(
+    bids_dir = ws_seq$bids_dir,
+    derivatives_dir = ws_seq$derivatives_dir,
+    cores = 1L
+  )
+
+  # Parallel
+  ws_par <- create_integration_workspace(dataset_dir)
+  withr::defer(cleanup_workspace(ws_par))
+  setup_regiondef_config(ws_par)
+
+  result_par <- petfit_regiondef_auto(
+    bids_dir = ws_par$bids_dir,
+    derivatives_dir = ws_par$derivatives_dir,
+    cores = 2L
+  )
+
+  expect_true(result_seq$success)
+  expect_true(result_par$success)
+
+  # Compare combined TACs files
+  tacs_seq <- readr::read_tsv(
+    file.path(ws_seq$derivatives_dir, "petfit", "desc-combinedregions_tacs.tsv"),
+    show_col_types = FALSE
+  )
+  tacs_par <- readr::read_tsv(
+    file.path(ws_par$derivatives_dir, "petfit", "desc-combinedregions_tacs.tsv"),
+    show_col_types = FALSE
+  )
+
+  expect_equal(nrow(tacs_seq), nrow(tacs_par))
+  expect_equal(sort(colnames(tacs_seq)), sort(colnames(tacs_par)))
+
+  # Compare numeric columns (TAC values should be identical)
+  expect_equal(tacs_seq$TAC, tacs_par$TAC)
+  expect_equal(tacs_seq$seg_meanTAC, tacs_par$seg_meanTAC)
+})
+
+# ---------------------------------------------------------------------------
+# Test: Parallel plasma pipeline runs successfully with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("plasma pipeline runs successfully with cores=2", {
+  skip_if_no_parallel()
+
+  ws <- setup_plasma_workspace_with_cores(cores = 2L)
+  withr::defer(cleanup_workspace(ws))
+
+  result <- petfit_modelling_auto(
+    bids_dir = ws$bids_dir,
+    derivatives_dir = ws$derivatives_dir,
+    cores = 2L
+  )
+
+  expect_true(result$success, info = paste(result$messages, collapse = "\n"))
+
+  # Check reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+
+  expect_true(length(report_files) >= 3,
+              info = paste("Expected at least 3 reports, found:", length(report_files)))
+})
+
+# ---------------------------------------------------------------------------
+# Test: Parallel reference pipeline runs successfully with cores=2
+# ---------------------------------------------------------------------------
+
+test_that("reference pipeline runs successfully with cores=2", {
+  skip_if_no_parallel()
+
+  ws <- setup_ref_workspace_with_cores(cores = 2L)
+  withr::defer(cleanup_workspace(ws))
+
+  result <- petfit_modelling_auto(
+    bids_dir = ws$bids_dir,
+    derivatives_dir = ws$derivatives_dir,
+    pipeline_type = "reference",
+    cores = 2L
+  )
+
+  expect_true(result$success, info = paste(result$messages, collapse = "\n"))
+
+  # Check reports were generated
+  analysis_dir <- file.path(ws$derivatives_dir, "petfit", "Primary_Analysis")
+  reports_dir <- file.path(analysis_dir, "reports")
+  report_files <- list.files(reports_dir, pattern = "\\.html$")
+
+  expect_true(length(report_files) >= 3,
+              info = paste("Expected at least 3 reports, found:", length(report_files)))
+})

--- a/tests/testthat/test-integration-singularity.R
+++ b/tests/testthat/test-integration-singularity.R
@@ -9,67 +9,6 @@
 # Script validation tests run with just PETFIT_INTEGRATION_TESTS=true (no container needed).
 
 # ---------------------------------------------------------------------------
-# Helper: locate singularity/apptainer command
-# ---------------------------------------------------------------------------
-
-get_singularity_cmd <- function() {
-  if (nchar(Sys.which("apptainer")) > 0) return("apptainer")
-  if (nchar(Sys.which("singularity")) > 0) return("singularity")
-  NULL
-}
-
-# ---------------------------------------------------------------------------
-# Helper: find or build container image
-# ---------------------------------------------------------------------------
-
-find_singularity_container <- function() {
-  # Check for explicit path
-  sif_path <- Sys.getenv("PETFIT_SINGULARITY_SIF", unset = "")
-  if (sif_path != "" && file.exists(sif_path)) {
-    return(sif_path)
-  }
-
-  # Check for a SIF in the singularity/ directory
-  pkg_root <- testthat::test_path("..", "..")
-  sif_candidates <- list.files(
-    file.path(pkg_root, "singularity"),
-    pattern = "\\.sif$",
-    full.names = TRUE
-  )
-  if (length(sif_candidates) > 0) {
-    return(sif_candidates[1])
-  }
-
-  # Try docker-daemon reference if Docker image exists
-  docker_check <- system2("docker", c("image", "inspect", "mathesong/petfit:latest"),
-                          stdout = FALSE, stderr = FALSE)
-  if (docker_check == 0L) {
-    return("docker-daemon://mathesong/petfit:latest")
-  }
-
-  NULL
-}
-
-# ---------------------------------------------------------------------------
-# Helper: set up workspace (same as Docker -- resolve symlinks)
-# ---------------------------------------------------------------------------
-
-setup_singularity_workspace <- function() {
-  dataset_dir <- ensure_testdata()
-  ws <- create_integration_workspace(dataset_dir)
-
-  # Singularity needs real paths for bind mounts
-  petprep_link <- file.path(ws$derivatives_dir, "petprep")
-  if (file.exists(petprep_link) && Sys.readlink(petprep_link) != "") {
-    real_path <- normalizePath(petprep_link)
-    unlink(petprep_link)
-    system2("cp", c("-a", real_path, petprep_link))
-  }
-
-  ws
-}
-
-# ---------------------------------------------------------------------------
 # Script validation (no container needed)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds parallel processing support using `future` + `furrr` throughout the petfit pipeline. When `--cores N` is passed (N > 1), model fitting and plot generation run across multiple workers, providing significant speedup for large datasets. Defaults to `cores = 1` (sequential) so existing behaviour is unchanged.

### Key changes

- **Parallel backend**: Uses `future::multicore` (fork-based, shared memory) on Unix systems for minimal serialisation overhead, with automatic fallback to `future::multisession` on Windows. Detection uses `future::supportsMulticore()` to handle edge cases (RStudio, Apple Silicon, Docker-on-Windows).

- **`group_by` antipattern fix**: Model fitting in reports used `group_by(output_stem, region) %>% mutate(fit = pmap(...))` where each group had exactly 1 row, making `future_pmap` useless. Removed the `group_by` before fitting calls so `future_pmap` parallelises across all regions/subjects at once.

- **Nonlinear model reports** — fitting + plot generation parallelised:
  `1tcm`, `2tcm`, `2tcmirr`, `srtm`, `srtm2`, `delay`

- **Linear model reports** — plot generation parallelised only (fitting is already fast, worker overhead would slow it down):
  `logan`, `ma1`, `reflogan`, `patlak`, `mrtm1`, `mrtm2`

- **Reference TAC report** — `feng1tc` and spline fitting parallelised

- **Region definition** (`R/region_utils.R`) — `create_petfit_combined_tacs()` parallelised via `furrr::future_map_dfr()`

- **`cores` parameter threaded** through the full call chain:
  `docker/run_petfit.R` (`--cores` CLI flag) → `R/docker_functions.R` → `R/launch_apps.R` → `R/pipeline_core.R` → `R/report_generation.R` → report templates (via `params$cores`)

- **Singularity scripts** (`run-automatic.sh`, `run-interactive.sh`) — added `--cores` argument parsing

### Plot rendering for large datasets

When a report has > 200 plots, fit and residual plots are saved to PNG files in a `reports/{report_name}_plots/` directory instead of being embedded inline in the HTML. This prevents report files from becoming unmanageably large. Below the threshold, plots are embedded as before.

### Integration tests

- **`test-integration-parallel.R`**: R-native tests verifying `cores=2` produces valid output for regiondef, plasma pipeline (2TCM), and reference pipeline (SRTM)
- **`test-integration-parallel-docker.R`**: Same tests run through Docker container with `--cores 2`
- **`test-integration-parallel-singularity.R`**: Same tests run through Singularity/Apptainer with `--cores 2`
- Container helper functions (`ensure_docker_image`, `setup_docker_workspace`, `find_singularity_container`, `setup_singularity_workspace`) moved from individual test files to `helper-integration.R` so they're shared across original and parallel test files
- GHA workflow updated: all three jobs set `PETFIT_PARALLEL_TESTS: "true"` and use wildcard filter patterns (`integration.*docker`, `integration.*singularity`) to pick up the new test files

### Dependencies added

- `future` — parallel backend
- `furrr` — `future_map`, `future_pmap` etc.
