### PR TITLE
Update apptainer run

### DIFF
--- a/R/modelling_plasma_app.R
+++ b/R/modelling_plasma_app.R
@@ -3168,7 +3168,11 @@ modelling_plasma_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_
   app <- shiny::shinyApp(ui = ui, server = server)
   
   # Run with Docker-compatible settings
+  shiny_port <- suppressWarnings(as.integer(Sys.getenv("PETFIT_SHINY_PORT", unset = "3838")))
+  if (is.na(shiny_port) || shiny_port < 1L || shiny_port > 65535L) {
+    shiny_port <- 3838L
+  }
   cat("If running from within a docker container, open one of the following addresses in your web browser.\n")
-  cat("http://localhost:3838\n")
-  shiny::runApp(app, host = "0.0.0.0", port = 3838)
+  cat("http://localhost:", shiny_port, "\n", sep = "")
+  shiny::runApp(app, host = "0.0.0.0", port = shiny_port)
 }

--- a/R/modelling_ref_app.R
+++ b/R/modelling_ref_app.R
@@ -2977,7 +2977,11 @@ modelling_ref_app <- function(bids_dir = NULL, derivatives_dir = NULL, blood_dir
   app <- shiny::shinyApp(ui = ui, server = server)
   
   # Run with Docker-compatible settings
+  shiny_port <- suppressWarnings(as.integer(Sys.getenv("PETFIT_SHINY_PORT", unset = "3838")))
+  if (is.na(shiny_port) || shiny_port < 1L || shiny_port > 65535L) {
+    shiny_port <- 3838L
+  }
   cat("If running from within a docker container, open one of the following addresses in your web browser.\n")
-  cat("http://localhost:3838\n")
-  shiny::runApp(app, host = "0.0.0.0", port = 3838)
+  cat("http://localhost:", shiny_port, "\n", sep = "")
+  shiny::runApp(app, host = "0.0.0.0", port = shiny_port)
 }

--- a/R/region_definition_app.R
+++ b/R/region_definition_app.R
@@ -1051,8 +1051,12 @@ region_definition_app <- function(bids_dir = NULL, derivatives_dir = NULL, petfi
   app <- shiny::shinyApp(ui = ui, server = server)
   
   # Run with Docker-compatible settings
+  shiny_port <- suppressWarnings(as.integer(Sys.getenv("PETFIT_SHINY_PORT", unset = "3838")))
+  if (is.na(shiny_port) || shiny_port < 1L || shiny_port > 65535L) {
+    shiny_port <- 3838L
+  }
   cat("Please open the address on the following line in your web browser.\n")
   cat("If that doesn't work, use the address from the next line:\n")
-  cat("http://localhost:3838\n")
-  shiny::runApp(app, host = "0.0.0.0", port = 3838)
+  cat("http://localhost:", shiny_port, "\n", sep = "")
+  shiny::runApp(app, host = "0.0.0.0", port = shiny_port)
 }

--- a/docker/run_petfit.R
+++ b/docker/run_petfit.R
@@ -71,6 +71,35 @@ if (!is.null(opt$ancillary_analysis_folder)) {
 }
 cat("\n")
 
+# Determine an available localhost port near the preferred one.
+is_port_available <- function(port) {
+  con <- tryCatch(
+    socketConnection(host = "127.0.0.1", port = port, open = "r+", blocking = TRUE, timeout = 0.2),
+    error = function(e) NULL
+  )
+
+  if (is.null(con)) {
+    return(TRUE)
+  }
+
+  close(con)
+  FALSE
+}
+
+find_open_port <- function(start_port = 3838L, max_offset = 20L) {
+  for (offset in seq.int(0L, max_offset)) {
+    candidate <- start_port + offset
+    if (is_port_available(candidate)) {
+      return(candidate)
+    }
+  }
+
+  stop(
+    "Could not find an open port between ", start_port, " and ", start_port + max_offset,
+    call. = FALSE
+  )
+}
+
 # Detect mounted directories
 detect_mounted_directories <- function() {
   # Prefer explicit paths when provided, otherwise fall back to conventional
@@ -137,8 +166,18 @@ cat("\n")
 
 # Execute based on mode
 if (opt$mode == "interactive") {
+  requested_port <- suppressWarnings(as.integer(Sys.getenv("SHINY_PORT", unset = "3838")))
+  if (is.na(requested_port) || requested_port < 1L || requested_port > 65535L) {
+    requested_port <- 3838L
+  }
+  selected_port <- find_open_port(requested_port)
+  if (selected_port != requested_port) {
+    cat("Requested Shiny port", requested_port, "is in use. Using", selected_port, "instead.\n")
+  }
+  Sys.setenv(PETFIT_SHINY_PORT = as.character(selected_port))
+
   cat("=== Starting Interactive Mode ===\n")
-  cat("Shiny app will be available at http://localhost:3838\n")
+  cat("Shiny app will be available at http://localhost:", selected_port, "\n", sep = "")
   cat("Container will exit when app is closed\n")
   cat("\n")
 

--- a/docker/run_petfit.R
+++ b/docker/run_petfit.R
@@ -2,7 +2,6 @@
 
 # Docker entry script for petfit apps
 # Supports both interactive and automatic modes with flexible directory mounting
-
 library(optparse)
 
 # Define command line options

--- a/docker/run_petfit.R
+++ b/docker/run_petfit.R
@@ -20,7 +20,13 @@ option_list <- list(
   make_option(c("--cores"), type="integer", default=1L,
               help="Number of cores for parallel processing [default: 1]"),
   make_option(c("--ancillary_analysis_folder"), type="character", default=NULL,
-              help="Name of sibling analysis folder to inherit delay/k2prime from [optional]")
+              help="Name of sibling analysis folder to inherit delay/k2prime from [optional]"),
+  make_option(c("--bids_dir"), type="character", default=NULL,
+              help="Explicit BIDS directory path inside container (optional; useful with Apptainer home auto-mounts)"),
+  make_option(c("--derivatives_dir"), type="character", default=NULL,
+              help="Explicit derivatives directory path inside container (optional; useful with Apptainer home auto-mounts)"),
+  make_option(c("--blood_dir"), type="character", default=NULL,
+              help="Explicit blood directory path inside container (optional; useful with Apptainer home auto-mounts)")
 )
 
 # Parse arguments
@@ -67,25 +73,40 @@ cat("\n")
 
 # Detect mounted directories
 detect_mounted_directories <- function() {
-  bids_available <- dir.exists("/data/bids_dir")
-  derivatives_available <- dir.exists("/data/derivatives_dir")
-  blood_available <- dir.exists("/data/blood_dir")
+  # Prefer explicit paths when provided, otherwise fall back to conventional
+  # bind mount locations used by Docker/Singularity wrapper scripts.
+  bids_candidate <- opt$bids_dir %||% "/data/bids_dir"
+  derivatives_candidate <- opt$derivatives_dir %||% "/data/derivatives_dir"
+  blood_candidate <- opt$blood_dir %||% "/data/blood_dir"
+
+  bids_available <- dir.exists(bids_candidate)
+  derivatives_available <- dir.exists(derivatives_candidate)
+  blood_available <- dir.exists(blood_candidate)
   
   cat("=== Directory Detection ===\n")
-  cat("BIDS directory mounted:", bids_available, "\n")
-  cat("Derivatives directory mounted:", derivatives_available, "\n")
-  cat("Blood directory mounted:", blood_available, "\n")
+  cat("BIDS directory available:", bids_available, "\n")
+  cat("Derivatives directory available:", derivatives_available, "\n")
+  cat("Blood directory available:", blood_available, "\n")
+  if (!is.null(opt$bids_dir)) {
+    cat("BIDS explicit path:", bids_candidate, "\n")
+  }
+  if (!is.null(opt$derivatives_dir)) {
+    cat("Derivatives explicit path:", derivatives_candidate, "\n")
+  }
+  if (!is.null(opt$blood_dir)) {
+    cat("Blood explicit path:", blood_candidate, "\n")
+  }
   cat("\n")
   
   # Validate at least one primary directory exists
   if (!bids_available && !derivatives_available) {
-    stop("At least one of bids_dir or derivatives_dir must be mounted", call.=FALSE)
+    stop("At least one of bids_dir or derivatives_dir must be available (bind mount or explicit path)", call.=FALSE)
   }
   
   # Set directory paths based on what's available
-  bids_dir <- if(bids_available) "/data/bids_dir" else NULL
-  derivatives_dir <- if(derivatives_available) "/data/derivatives_dir" else NULL
-  blood_dir <- if(blood_available) "/data/blood_dir" else NULL
+  bids_dir <- if (bids_available) bids_candidate else NULL
+  derivatives_dir <- if (derivatives_available) derivatives_candidate else NULL
+  blood_dir <- if (blood_available) blood_candidate else NULL
   
   return(list(
     bids_dir = bids_dir,

--- a/singularity/petfit.def
+++ b/singularity/petfit.def
@@ -33,6 +33,9 @@ From: rocker/shiny-verse:latest
     # Install kinfitr from GitHub
     R -e "remotes::install_github('mathesong/kinfitr', dependencies = TRUE)"
 
+    # Install petfit from local source copied into /app
+    R -e "remotes::install_local('/app', dependencies = TRUE)"
+
     # Create app directory and set permissions
     mkdir -p /app
     chown -R {{ USER_NAME }}:{{ USER_NAME }} /app
@@ -67,5 +70,8 @@ From: rocker/shiny-verse:latest
     
     Automatic mode:
     singularity run petfit.sif --func modelling --mode automatic
+
+    Apptainer without explicit --bind (if host paths are auto-mounted):
+    apptainer run petfit.sif --func regiondef --bids_dir /home/USER/path/to/bids
     
     For detailed usage information, see the singularity/README.md file.


### PR DESCRIPTION
Adds the following:

- Chooses an open port for shiny instead of defaulting to 3838.
- Allows direct passing of paths when running apptainer (home folder is automatically bound, others can be added per system with apptainer config.

This is a bit goofy as it adds in a duplicate set of input arguments, but I did that as didn't want to mess with any current functionality. Users are running this PR as is with apptainer and are happy with not needing to bind ports or volumes as with docker (or apptainer either). Would like to have a discussion about maybe providing an alternative interface or shaking out the cli for petfit in general, because with an alias and config file this makes for a slick setup:

```bash
alias petfit='apptainer run /opt/petfit/petfit_latest.sif'
        /usr/bin/apptainer
```

And the bindpath arg in apptainer config:

```bash 
# BIND PATH: [STRING]
# DEFAULT: Undefined
# Define a list of files/directories that should be made available from within
# the container. The file or directory must exist within the container on
# which to attach to. you can specify a different source and destination
# path (respectively) with a colon; otherwise source and dest are the same.
# NOTE: these are ignored if apptainer is invoked with --contain except
# for /etc/hosts and /etc/localtime. When invoked with --contain and --net,
# /etc/hosts would contain a default generated content for localhost resolution.

bind path = /some/sharedfolder
```

Then the whole thing can be run as:

```bash
petfit  --func regiondef --bids-dir /some/sharedfolder/bids_data --petfit_output_foldername petfit/ 
```
  