### PR TITLE
ENH: Fix reference TAC spline handling and SUVR all-frame display

### DIFF
--- a/inst/rmd/reference_tac_report.Rmd
+++ b/inst/rmd/reference_tac_report.Rmd
@@ -39,6 +39,123 @@ if (cores > 1) {
 
 theme_set(theme_light())
 
+constant_reference_tac_fit <- function(t_tac, tac, weights = NULL, reason = "") {
+  if (is.null(weights)) {
+    weights <- rep(1, length(tac))
+  }
+
+  fitted_tac <- weighted.mean(tac, w = weights, na.rm = TRUE)
+
+  structure(
+    list(
+      tacs = tibble(
+        Time = t_tac,
+        TAC = tac,
+        TAC_fitted = rep(fitted_tac, length(tac))
+      ),
+      par = tibble(t0 = min(t_tac, na.rm = TRUE)),
+      fit_message = reason,
+      petfit_constant_fallback = TRUE
+    ),
+    class = c("petfit_constant_reference_tac_fit", "list")
+  )
+}
+
+fit_reference_spline_tac <- function(t_tac, tac, weights = NULL, spline_df = NULL) {
+  spline_df <- as.numeric(spline_df %||% NA_real_)
+
+  if (!is.na(spline_df) && spline_df < 2) {
+    return(constant_reference_tac_fit(
+      t_tac = t_tac,
+      tac = tac,
+      weights = weights,
+      reason = str_glue("Spline degrees of freedom ({spline_df}) is below 2; using a weighted constant fit.")
+    ))
+  }
+
+  if (!exists("spline_tac", mode = "function")) {
+    stop("spline_tac() is not available. Please check that the installed kinfitr version supports reference TAC spline fitting.")
+  }
+
+  spline_args <- list(
+    t_tac = t_tac,
+    tac = tac,
+    weights = weights
+  )
+
+  spline_formals <- names(formals(spline_tac))
+  if (!is.na(spline_df) && "df" %in% spline_formals) {
+    spline_args$df <- spline_df
+  } else if (!is.na(spline_df) && "k" %in% spline_formals) {
+    spline_args$k <- spline_df
+  }
+
+  tryCatch(
+    do.call(spline_tac, spline_args),
+    error = function(e) {
+      constant_reference_tac_fit(
+        t_tac = t_tac,
+        tac = tac,
+        weights = weights,
+        reason = str_glue("Spline fit failed ({e$message}); using a weighted constant fit.")
+      )
+    }
+  )
+}
+
+reference_spline_predictions <- function(ref_fit, ref_tacs) {
+  if (!all(c("Time", "TAC_fitted") %in% colnames(ref_fit$tacs))) {
+    stop("Spline fit output does not contain Time and TAC_fitted columns.")
+  }
+
+  original_time <- ref_tacs$frame_mid / 60
+  fit_time <- ref_fit$tacs$Time
+
+  # Some spline fits return a dense, zero-based prediction grid rather than one
+  # fitted value per original PET frame. Interpolate back onto the original frame
+  # midpoints so downstream files and plots keep the BIDS TAC timing.
+  if (!(min(fit_time, na.rm = TRUE) <= min(original_time, na.rm = TRUE) &&
+        max(fit_time, na.rm = TRUE) >= max(original_time, na.rm = TRUE))) {
+    shifted_fit_time <- fit_time + min(original_time, na.rm = TRUE) - min(fit_time, na.rm = TRUE)
+
+    if (min(shifted_fit_time, na.rm = TRUE) <= min(original_time, na.rm = TRUE) &&
+        max(shifted_fit_time, na.rm = TRUE) >= max(original_time, na.rm = TRUE)) {
+      fit_time <- shifted_fit_time
+    }
+  }
+
+  fitted_tac <- approx(
+    x = fit_time,
+    y = ref_fit$tacs$TAC_fitted,
+    xout = original_time,
+    rule = 2,
+    ties = "ordered"
+  )$y
+
+  ref_tacs %>%
+    transmute(
+      frame_start,
+      frame_mid,
+      RefTAC = RefTAC,
+      RefTAC_fitted = fitted_tac
+    )
+}
+
+plot_reference_spline_fit <- function(ref_fit, ref_tacs) {
+  plot_data <- reference_spline_predictions(ref_fit, ref_tacs) %>%
+    mutate(
+      plot_time = frame_mid / 60,
+      plot_start = frame_start / 60
+    )
+
+  ggplot(plot_data, aes(x = plot_time, y = RefTAC)) +
+    geom_point(colour = "black") +
+    geom_line(aes(y = RefTAC_fitted), colour = "black") +
+    coord_cartesian(xlim = range(plot_data$plot_start, plot_data$plot_time, na.rm = TRUE)) +
+    labs(x = "Time (min)", y = "Radioactivity (kBq)") +
+    theme_light()
+}
+
 # Use parameters (from params or debugging section above)
 analysis_folder <- params$analysis_folder
 bids_dir <- params$bids_dir
@@ -640,17 +757,23 @@ ref_tac_fitdata <- ref_tac_data %>%
   ungroup()
 
 ref_tac_fitdata <- ref_tac_fitdata %>%
-  mutate(ref_fit = future_map(ref_tacs, ~spline_tac(t_tac   = .x$frame_mid/60,
-                                              tac     = .x$RefTAC,
-                                              weights = .x$ref_weights),
+  mutate(ref_fit = future_map(ref_tacs, ~fit_reference_spline_tac(t_tac     = .x$frame_mid/60,
+                                                                  tac       = .x$RefTAC,
+                                                                  weights   = .x$ref_weights,
+                                                                  spline_df = spline_df),
                               .options = furrr_options(seed = TRUE)))
 
+spline_fit_messages <- ref_tac_fitdata %>%
+  mutate(fit_message = map_chr(ref_fit, ~.x$fit_message %||% "")) %>%
+  filter(fit_message != "") %>%
+  select(any_of(c("sub", "ses", "trc", "rec", "task", "run", "pet")), fit_message)
+
+if (nrow(spline_fit_messages) > 0) {
+  print(kable(spline_fit_messages, caption = "Spline fitting fallbacks"))
+}
+
 ref_tac_preddata <- ref_tac_fitdata %>%
-  mutate(ref_preds = map(ref_fit, ~.x$tacs %>%
-                          rename(frame_mid = Time,
-                                 RefTAC = TAC,
-                                 RefTAC_fitted = TAC_fitted) %>%
-                           mutate(frame_mid = frame_mid*60))) %>%
+  mutate(ref_preds = map2(ref_fit, ref_tacs, reference_spline_predictions)) %>%
   select(-ref_fit) %>%
   mutate(ref_tacs = map2(ref_tacs, ref_preds, inner_join)) %>%
   mutate(ref_tacs = map(ref_tacs, ~.x %>%
@@ -718,9 +841,10 @@ str_glue("### Spline Reference Model Plots")
 ```
 
 ```{r spline-plotting, eval=use_spline, echo=use_spline}
-walk2(ref_tac_fitdata$ref_fit,
-      ref_tac_fitdata$pet, 
-      ~print(plot(.x) + labs(title = .y)))
+pwalk(list(ref_tac_fitdata$ref_fit,
+          ref_tac_fitdata$ref_tacs,
+          ref_tac_fitdata$pet),
+     ~print(plot_reference_spline_fit(..1, ..2) + labs(title = ..3)))
 ```
 
 

--- a/inst/rmd/suvr_report.Rmd
+++ b/inst/rmd/suvr_report.Rmd
@@ -1,0 +1,465 @@
+---
+title: "SUVR Estimation Report"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    toc_depth: 2
+    code_folding: hide
+params:
+  cores: 1
+  model_number: "Model 1"
+  analysis_folder: NULL
+  bids_dir: NULL
+  blood_dir: NULL
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = FALSE)
+library(tidyverse)
+library(kinfitr)
+library(knitr)
+library(jsonlite)
+library(glue)
+library(DT)
+library(furrr)
+
+cores <- params$cores %||% 1
+if (cores > 1) {
+  if (future::supportsMulticore()) {
+    future::plan(future::multicore, workers = cores)
+  } else {
+    future::plan(future::multisession, workers = cores)
+  }
+} else {
+  future::plan(future::sequential)
+}
+
+theme_set(theme_light())
+
+analysis_folder <- params$analysis_folder
+model_number <- params$model_number
+bids_dir <- params$bids_dir
+
+config_path <- file.path(analysis_folder, "desc-petfitoptions_config.json")
+config <- NULL
+if (file.exists(config_path)) {
+  tryCatch({
+    config <- jsonlite::fromJSON(config_path)
+    config <- coerce_bounds_numeric(config)
+  }, error = function(e) {
+    cat("Warning: Could not load config file:", e$message, "\n")
+  })
+} else {
+  cat("Config file not found at:", config_path, "\n")
+}
+```
+
+```{r cleanup-old, include=FALSE}
+desc <- str_remove(str_to_lower(model_number), " ")
+oldfiles <- list.files(analysis_folder, pattern = desc,
+                       recursive = TRUE, full.names = TRUE)
+file.remove(oldfiles)
+```
+
+This report estimates Standardised Uptake Value Ratios (SUVR) as a target-to-reference tissue ratio over a configured frame or time window.
+
+The calculation mirrors the regional TAC ratio approach described by Turku PET Centre's `dftratio`: the outcome is the regional AUC over the selected interval divided by the reference AUC over the same interval. Concentration units cancel out, so the same ratio is obtained from radioactivity concentration or SUV TACs.
+
+# Analysis Configuration
+
+**Model:** `r params$model_number` - SUVR (AUC ratio)
+
+**Analysis folder:** `r params$analysis_folder`
+
+**Generated on:** `r format(Sys.time(), "%Y-%m-%d %H:%M:%S")`
+
+# Model Configuration
+
+```{r model-config}
+model_config <- NULL
+if (!is.null(config$Models)) {
+  if (params$model_number == "Model 1") {
+    model_config <- config$Models$Model1
+  } else if (params$model_number == "Model 2") {
+    model_config <- config$Models$Model2
+  } else if (params$model_number == "Model 3") {
+    model_config <- config$Models$Model3
+  }
+}
+
+if (!is.null(model_config) && model_config$type == "SUVR") {
+  config_items <- list("Model Type" = "SUVR (target-to-reference AUC ratio)")
+
+  if (!is.null(model_config$subset) &&
+      (model_config$subset$type %||% "none") != "none") {
+    subset_info <- paste0(
+      "Type: ", model_config$subset$type %||% "none",
+      ", Start: ", model_config$subset$start %||% "Not set",
+      ", End: ", model_config$subset$end %||% "Not set"
+    )
+    config_items[["Window"]] <- subset_info
+  } else {
+    config_items[["Window"]] <- "Use all frames"
+  }
+
+  config_df <- tibble(
+    Parameter = names(config_items),
+    Value = map_chr(config_items, as.character)
+  )
+
+  kable(config_df, caption = "SUVR Configuration")
+} else {
+  cat("SUVR configuration not found or incomplete.")
+}
+```
+
+```{r setup-conditions, echo=FALSE}
+has_suvr_config <- !is.null(model_config) && model_config$type == "SUVR"
+
+if (!has_suvr_config) {
+  cat("Invalid or missing SUVR configuration. This report should not have been generated.")
+  knitr::knit_exit()
+}
+```
+
+# Loading Data
+
+```{r load-tacs}
+tacs_files <- list.files(analysis_folder,
+                         pattern = "*_desc-targetregions_tacs.tsv",
+                         recursive = TRUE)
+
+if (length(tacs_files) == 0) {
+  stop("No target TAC files found in analysis folder: ", analysis_folder)
+}
+
+tac_data <- tibble(filename = tacs_files) %>%
+  mutate(basename = basename(filename)) %>%
+  mutate(attributes = map(filename, kinfitr:::bids_filename_attributes)) %>%
+  unnest(attributes) %>%
+  group_by(filename) %>%
+  mutate(tacs = map(filename, ~read_tsv(file.path(analysis_folder, .x), show_col_types = FALSE))) %>%
+  ungroup() %>%
+  unnest(tacs) %>%
+  select(-basename, -measurement, -desc)
+
+ref_files <- list.files(analysis_folder,
+                        pattern = "*_desc-ref_tacs.tsv",
+                        recursive = TRUE)
+
+if (length(ref_files) == 0) {
+  stop("No reference TAC files found in analysis folder: ", analysis_folder)
+}
+
+ref_data <- tibble(filename = ref_files) %>%
+  mutate(basename = basename(filename)) %>%
+  mutate(attributes = map(filename, kinfitr:::bids_filename_attributes)) %>%
+  unnest(attributes) %>%
+  group_by(filename) %>%
+  mutate(ref_tacs = map(filename, ~read_tsv(file.path(analysis_folder, .x), show_col_types = FALSE))) %>%
+  ungroup() %>%
+  unnest(ref_tacs) %>%
+  select(-basename, -measurement, -desc, -filename) %>%
+  select(-any_of("volume_mm3"))
+```
+
+```{r combine-data}
+model_data <- tac_data %>%
+  inner_join(ref_data) %>%
+  group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
+                                           "run", "pet", "filename", "region")))) %>%
+  mutate(frame_start = frame_start / 60,
+         frame_end = frame_end / 60,
+         frame_dur = frame_dur / 60,
+         frame_mid = frame_mid / 60) %>%
+  arrange(frame_start, .by_group = TRUE) %>%
+  nest(.key = "tacs") %>%
+  ungroup() %>%
+  mutate(output_stem = filename) %>%
+  select(-filename) %>%
+  mutate(output_stem = str_remove(output_stem, "_desc.*")) %>%
+  mutate(output_stem = str_remove(output_stem, "_tacs.*"))
+```
+
+# SUVR Estimation
+
+```{r suvr-functions}
+subset_config <- model_config$subset
+subset_type <- subset_config$type %||% "none"
+start_point <- subset_config$start
+end_point <- subset_config$end
+
+is_empty <- function(x) {
+  is.null(x) || length(x) == 0 || is.na(x)
+}
+
+estimate_suvr <- function(tac, subset_type = "none", start_point = NULL, end_point = NULL) {
+  tac <- tac %>%
+    arrange(frame_start) %>%
+    mutate(frame_index = row_number())
+
+  if (is_empty(start_point) && is_empty(end_point)) {
+    windowed <- tac %>%
+      mutate(window_duration = frame_dur,
+             included = TRUE)
+    window_start <- min(tac$frame_start, na.rm = TRUE)
+    window_end <- max(tac$frame_end, na.rm = TRUE)
+  } else if (!is_empty(start_point) && !is_empty(end_point) &&
+             as.numeric(start_point) == 0 && as.numeric(end_point) == 0) {
+    windowed <- tac %>%
+      mutate(window_duration = frame_dur,
+             included = TRUE)
+    window_start <- min(tac$frame_start, na.rm = TRUE)
+    window_end <- max(tac$frame_end, na.rm = TRUE)
+  } else if (subset_type == "frame") {
+    frame_start_index <- as.integer(start_point %||% 1)
+    frame_end_index <- as.integer(end_point %||% nrow(tac))
+    windowed <- tac %>%
+      mutate(included = frame_index >= frame_start_index & frame_index <= frame_end_index,
+             window_duration = if_else(included, frame_dur, 0))
+    window_start <- min(windowed$frame_start[windowed$included], na.rm = TRUE)
+    window_end <- max(windowed$frame_end[windowed$included], na.rm = TRUE)
+  } else if (subset_type == "time") {
+    window_start <- as.numeric(start_point %||% min(tac$frame_start, na.rm = TRUE))
+    window_end <- as.numeric(end_point %||% max(tac$frame_end, na.rm = TRUE))
+    windowed <- tac %>%
+      mutate(window_duration = pmax(0, pmin(frame_end, window_end) - pmax(frame_start, window_start)),
+             included = window_duration > 0)
+  } else {
+    windowed <- tac %>%
+      mutate(window_duration = frame_dur,
+             included = TRUE)
+    window_start <- min(tac$frame_start, na.rm = TRUE)
+    window_end <- max(tac$frame_end, na.rm = TRUE)
+  }
+
+  selected <- windowed %>%
+    filter(included, window_duration > 0)
+
+  if (nrow(selected) == 0) {
+    return(list(
+      par = tibble(
+        SUVR = NA_real_,
+        target_auc = NA_real_,
+        reference_auc = NA_real_,
+        target_uptake = NA_real_,
+        reference_uptake = NA_real_,
+        window_start = window_start,
+        window_end = window_end,
+        window_duration = 0,
+        n_frames = 0
+      ),
+      fitvals = windowed
+    ))
+  }
+
+  target_auc <- sum(selected$TAC * selected$window_duration, na.rm = TRUE)
+  reference_auc <- sum(selected$RefTAC * selected$window_duration, na.rm = TRUE)
+  window_duration <- sum(selected$window_duration, na.rm = TRUE)
+
+  list(
+    par = tibble(
+      SUVR = target_auc / reference_auc,
+      target_auc = target_auc,
+      reference_auc = reference_auc,
+      target_uptake = target_auc / window_duration,
+      reference_uptake = reference_auc / window_duration,
+      window_start = window_start,
+      window_end = window_end,
+      window_duration = window_duration,
+      n_frames = nrow(selected)
+    ),
+    fitvals = windowed
+  )
+}
+```
+
+```{r suvr-estimation}
+model_data <- model_data %>%
+  mutate(suvr_result = future_map(
+    tacs,
+    ~estimate_suvr(.x, subset_type, start_point, end_point),
+    .options = furrr_options(seed = TRUE)
+  )) %>%
+  mutate(par = map(suvr_result, "par"),
+         fitvals = map(suvr_result, "fitvals"),
+         success = map_lgl(par, ~nrow(.x) == 1 && is.finite(.x$SUVR)))
+```
+
+```{r estimation-summary, results='asis'}
+success_n <- sum(model_data$success)
+tot_n <- nrow(model_data)
+
+str_glue("SUVR successfully estimated for {success_n} / {tot_n} ({round(100 * success_n / tot_n)}%) of measurements.
+
+         SUVR estimation unsuccessful for {tot_n - success_n} / {tot_n} ({100 - round(100 * success_n / tot_n)}%) of measurements.")
+```
+
+# Results
+
+```{r results-table}
+model_data <- model_data %>%
+  filter(success)
+
+par_table <- model_data %>%
+  ungroup() %>%
+  select(-tacs, -suvr_result, -fitvals, -output_stem) %>%
+  unnest(par)
+
+par_table %>%
+  select(where(~ n_distinct(.x) > 1)) %>%
+  mutate(across(where(is.numeric), ~round(.x, 3))) %>%
+  DT::datatable()
+```
+
+## Parameter Plots
+
+This plot keeps PET measurements explicit. Each panel shows one region, bar height is SUVR, and tracer is encoded by colour. For most analyses the tracer colour will be constant, but it remains visible if the analysis intentionally includes multiple tracers.
+
+```{r suvr-plot-data}
+plot_table <- par_table %>%
+  mutate(
+    tracer_label = if_else(is.na(trc) | trc == "", "Tracer not specified", trc),
+    measurement_label = pmap_chr(
+      select(., any_of(c("sub", "ses", "task", "run"))),
+      ~{
+        attrs <- list(...)
+        attrs <- attrs[!is.na(attrs) & attrs != ""]
+        if (length(attrs) == 0) {
+          "measurement"
+        } else {
+          paste(paste(names(attrs), attrs, sep = "-"), collapse = "\n")
+        }
+      }
+    )
+  )
+```
+
+```{r suvr-region-bars, fig.width=10, fig.height=6}
+ggplot(plot_table, aes(x = measurement_label, y = SUVR, fill = tracer_label)) +
+  geom_col(position = position_dodge2(width = 0.8, preserve = "single"), colour = "black", width = 0.75) +
+  facet_wrap(~region, scales = "free_x") +
+  labs(x = "Measurement", y = "SUVR", fill = "Tracer") +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
+
+# Saving Parameters
+
+## Main TSV
+
+```{r save-main-parameters}
+savepar <- par_table
+
+write_tsv(savepar,
+          file = paste0(analysis_folder, "/",
+                        "model_", "SUVR", "_",
+                        "desc-", desc, "_",
+                        "kinpar.tsv"))
+```
+
+## PET Folder TSVs
+
+```{r save-pet-parameters}
+folder_data <- tibble(filename = tacs_files) %>%
+  mutate(basename = basename(filename)) %>%
+  mutate(attributes = map(filename, kinfitr:::bids_filename_attributes)) %>%
+  unnest(attributes) %>%
+  mutate(dirname = dirname(filename)) %>%
+  select(-filename, -basename, -measurement, -desc)
+
+savepar_pet <- savepar %>%
+  group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
+                                           "run", "pet")))) %>%
+  nest(.key = "kinpars") %>%
+  inner_join(folder_data) %>%
+  mutate(filename = paste0(analysis_folder, "/", dirname, "/", pet, "_",
+                           "model_", "SUVR", "_",
+                           "desc-", desc, "_",
+                           "kinpar.tsv"))
+
+walk2(savepar_pet$kinpars, savepar_pet$filename, ~write_tsv(.x, .y))
+```
+
+```{r save-parameter-json}
+savepar_pet <- savepar_pet %>%
+  group_by(pet) %>%
+  mutate(jsondat = map(kinpars, ~list(
+    Description = "Standardised Uptake Value Ratio estimated as target-to-reference tissue AUC ratio.",
+    ModelName = "SUVR",
+    AdditionalModelDetails = "Reference tissue ratio - no blood data required",
+    SUVR = "Target region AUC divided by reference region AUC over the selected window",
+    target_auc = "Target region area under the TAC over the selected window",
+    reference_auc = "Reference region area under the TAC over the selected window",
+    target_uptake = "Frame-duration weighted target uptake over the selected window",
+    reference_uptake = "Frame-duration weighted reference uptake over the selected window",
+    window_start = "Window start time in minutes",
+    window_end = "Window end time in minutes",
+    window_duration = "Total included frame duration in minutes",
+    n_frames = "Number of frames included in the ratio"
+  ))) %>%
+  mutate(jsondat = jsonlite::toJSON(jsondat, pretty = TRUE, auto_unbox = TRUE)) %>%
+  mutate(filename_json = str_replace(filename, ".tsv", ".json"))
+
+walk2(savepar_pet$jsondat,
+      savepar_pet$filename_json,
+      ~writeLines(.x, .y))
+```
+
+# Saving Ratio Inputs
+
+```{r save-fitvals}
+savefits <- model_data %>%
+  filter(success) %>%
+  select(any_of(c("sub", "ses", "task", "trc", "run",
+                  "rec", "pet", "region")), fitvals) %>%
+  unnest(cols = c("fitvals")) %>%
+  select(any_of(c("sub", "ses", "task", "trc", "run", "rec", "pet", "region",
+                  "frame_start", "frame_end", "frame_mid", "frame_dur",
+                  "TAC", "RefTAC", "included", "window_duration"))) %>%
+  group_by(across(intersect(colnames(.), c("sub", "ses", "trc", "rec", "task",
+                                           "run", "pet")))) %>%
+  nest(.key = "fitvals")
+
+savefits_pet <- savefits %>%
+  inner_join(folder_data) %>%
+  mutate(filename = paste0(analysis_folder, "/", dirname, "/", pet, "_",
+                           "model_", "SUVR", "_",
+                           "desc-", desc, "ratioinput",
+                           "_",
+                           "tacs.tsv"))
+
+walk2(savefits_pet$fitvals, savefits_pet$filename, ~write_tsv(.x, .y))
+```
+
+```{r save-fitvals-json}
+savefits_pet <- savefits_pet %>%
+  group_by(pet) %>%
+  mutate(jsondat = map(fitvals, ~list(
+    Description = "TAC values used for SUVR ratio estimation.",
+    ModelName = "SUVR",
+    frame_start = "Frame start time in minutes",
+    frame_end = "Frame end time in minutes",
+    frame_mid = "Frame middle time in minutes",
+    TAC = "Target region TAC radioactivity data",
+    RefTAC = "Reference region TAC radioactivity data",
+    included = "Whether the frame contributed to the selected ratio window",
+    window_duration = "Frame duration within the selected window in minutes"
+  ))) %>%
+  mutate(jsondat = jsonlite::toJSON(jsondat, pretty = TRUE, auto_unbox = TRUE)) %>%
+  mutate(filename_json = str_replace(filename, ".tsv", ".json"))
+
+walk2(savefits_pet$jsondat,
+      savefits_pet$filename_json,
+      ~writeLines(.x, .y))
+```
+
+```{r cleanup, include=FALSE}
+future::plan(future::sequential)
+```
+
+# Session Information
+
+```{r session-info}
+sessionInfo()
+```


### PR DESCRIPTION
This PR addresses issue #38, fixing several report-level issues in reference TAC spline fitting and SUVR configuration display. 

Changes include:

1. Pass the configured reference TAC spline degrees of freedom into spline_tac() when supported.
2. Add a weighted constant fallback for steady-state or low-DF spline cases, including spline_df < 2, where spline basis construction can fail.
3. Plot spline-fitted reference TACs using the original PET frame timing instead of the internal spline_tac() plot grid, avoiding misleading curves starting at time zero for delayed-start acquisitions.