### PR TITLE
FIX: Fix TAC discovery for seg-* files without label-* entity

### DIFF
--- a/R/region_utils.R
+++ b/R/region_utils.R
@@ -1153,6 +1153,13 @@ summarise_tacs_descriptions <- function(dir_path) {
   # Filter for files with seg or label attributes (silently exclude others)
   # kinfitr::bids_parse_files() should provide seg and label columns if present
   if ("seg" %in% colnames(unnested_tacfiledata) || "label" %in% colnames(unnested_tacfiledata)) {
+    if (!"seg" %in% colnames(unnested_tacfiledata)) {
+      unnested_tacfiledata$seg <- NA_character_
+    }
+    if (!"label" %in% colnames(unnested_tacfiledata)) {
+      unnested_tacfiledata$label <- NA_character_
+    }
+
     unnested_tacfiledata <- unnested_tacfiledata %>%
       dplyr::filter(!is.na(seg) | !is.na(label))
   } else {

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -12,3 +12,7 @@
 #' @param rhs A function call using the magrittr semantics.
 #' @return The result of calling `rhs(lhs)`.
 NULL
+
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}

--- a/tests/testthat/test-region_utils.R
+++ b/tests/testthat/test-region_utils.R
@@ -65,3 +65,41 @@ test_that("summarise_tacs_descriptions handles seg-only TACs without label entit
   expect_equal(nrow(descriptions), 1)
   expect_equal(descriptions$description, "seg-hammers_desc-preproc")
 })
+
+test_that("summarise_tacs_descriptions handles label-only TACs without seg entity", {
+  pipeline_dir <- file.path(tempdir(), "petfit_label_only_tacs")
+  unlink(pipeline_dir, recursive = TRUE)
+
+  pet_dir <- file.path(pipeline_dir, "sub-01", "ses-test", "pet")
+  dir.create(pet_dir, recursive = TRUE, showWarnings = FALSE)
+  file.create(file.path(
+    pet_dir,
+    "sub-01_ses-test_trc-11CMC1_desc-preproc_label-cerebellum_tacs.tsv"
+  ))
+
+  descriptions <- summarise_tacs_descriptions(pipeline_dir)
+
+  expect_equal(nrow(descriptions), 1)
+  expect_equal(descriptions$description, "label-cerebellum_desc-preproc")
+})
+
+test_that("create_tacs_list discovers seg-only TACs with matching morph files", {
+  derivatives_dir <- file.path(tempdir(), "petfit_seg_only_derivatives")
+  unlink(derivatives_dir, recursive = TRUE)
+
+  pipeline_dir <- file.path(derivatives_dir, "pmod")
+  pet_dir <- file.path(pipeline_dir, "sub-11", "ses-test", "pet")
+  anat_dir <- file.path(pipeline_dir, "sub-11", "ses-test", "anat")
+  purrr::walk(c(pet_dir, anat_dir), dir.create, recursive = TRUE, showWarnings = FALSE)
+
+  tacs_file <- file.path(pet_dir, "sub-11_ses-test_trc-11CMC1_desc-preproc_seg-hammers_tacs.tsv")
+  morph_file <- file.path(anat_dir, "sub-11_ses-test_desc-preproc_seg-hammers_morph.tsv")
+  file.create(c(tacs_file, morph_file))
+
+  tacs_list <- create_tacs_list(derivatives_dir)
+
+  expect_equal(nrow(tacs_list), 1L)
+  expect_equal(tacs_list$tacs_path, tacs_file)
+  expect_equal(tacs_list$morph_path, morph_file)
+  expect_equal(tacs_list$description, "seg-hammers_desc-preproc")
+})

--- a/tests/testthat/test-region_utils.R
+++ b/tests/testthat/test-region_utils.R
@@ -48,3 +48,20 @@ test_that("create_tacs_morph_mapping does not choose an ambiguous cross-session 
 
   expect_equal(nrow(mapping), 0)
 })
+
+test_that("summarise_tacs_descriptions handles seg-only TACs without label entity", {
+  pipeline_dir <- file.path(tempdir(), "petfit_seg_only_tacs")
+  unlink(pipeline_dir, recursive = TRUE)
+
+  pet_dir <- file.path(pipeline_dir, "sub-01", "ses-test", "pet")
+  dir.create(pet_dir, recursive = TRUE, showWarnings = FALSE)
+  file.create(file.path(
+    pet_dir,
+    "sub-01_ses-test_trc-11CMC1_desc-preproc_seg-hammers_tacs.tsv"
+  ))
+
+  descriptions <- summarise_tacs_descriptions(pipeline_dir)
+
+  expect_equal(nrow(descriptions), 1)
+  expect_equal(descriptions$description, "seg-hammers_desc-preproc")
+})


### PR DESCRIPTION
This PR addresses issue #41, fixing TAC discovery in the region definition app for valid BIDS-like derivatives that include a seg-* entity but no label-* entity, such as:

> sub-01_ses-test_trc-11CMC1_desc-preproc_seg-hammers_tacs.tsv

Previously, summarise_tacs_descriptions() checked whether either seg or label existed, but then filtered using both columns:

`dplyr::filter(!is.na(seg) | !is.na(label))`

When only seg was present, the missing label column caused an internal error. The Shiny app caught that error and displayed the misleading message:

`No TACs Files Found`

even though valid TAC files were present.

This PR:

1. Handles TAC metadata tables that contain only seg or only label by adding the missing optional column as NA.
.2 Adds the missing internal %||% helper used by filename parsing and app code.
3. Adds a regression test using a PMOD-style filename:
sub-01_ses-test_trc-11CMC1_desc-preproc_seg-hammers_tacs.tsv

Expected result: region definition now correctly discovers seg-* TAC files without requiring a label-* entity.